### PR TITLE
updating contracts to support Cairo 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Under this model we can build a simple yet highly secure non-custodial wallet.
 
 ## Development
 
-### Install Cairo 0.5.0
+### Install Cairo 0.5.1
 
 See https://www.cairo-lang.org/docs/quickstart.html
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Under this model we can build a simple yet highly secure non-custodial wallet.
 
 ## Development
 
-### Install Cairo
+### Install Cairo 0.5.0
 
 See https://www.cairo-lang.org/docs/quickstart.html
 

--- a/contracts/ArgentAccount.cairo
+++ b/contracts/ArgentAccount.cairo
@@ -125,9 +125,7 @@ func change_signer{
         range_check_ptr
     } (
         new_signer: felt,
-        nonce: felt,
-        sig_len: felt,
-        sig: felt*
+        nonce: felt
     ):
     alloc_locals
 
@@ -159,9 +157,7 @@ func change_guardian{
         range_check_ptr
     } (
         new_guardian: felt,
-        nonce: felt,
-        sig_len: felt,
-        sig: felt*
+        nonce: felt
     ):
     alloc_locals
 
@@ -193,9 +189,7 @@ func change_L1_address{
         range_check_ptr
     } (
         new_L1_address: felt,
-        nonce: felt,
-        sig_len: felt,
-        sig: felt*
+        nonce: felt
     ):
     alloc_locals
 
@@ -226,9 +220,7 @@ func trigger_escape{
         range_check_ptr
     } (
         escapor: felt,
-        nonce: felt,
-        sig_len: felt,
-        sig: felt*
+        nonce: felt
     ):
     alloc_locals
 
@@ -279,9 +271,7 @@ func cancel_escape{
         ecdsa_ptr: SignatureBuiltin*,
         range_check_ptr
     } (
-        nonce: felt,
-        sig_len: felt,
-        sig: felt*
+        nonce: felt
     ):
     alloc_locals
 
@@ -316,9 +306,7 @@ func escape_guardian{
         range_check_ptr
     } (
         new_guardian: felt,
-        nonce: felt,
-        sig_len: felt,
-        sig: felt*
+        nonce: felt
     ):
     alloc_locals
 
@@ -359,9 +347,7 @@ func escape_signer{
         range_check_ptr
     } (
         new_signer: felt,
-        nonce: felt,
-        sig_len: felt,
-        sig: felt*
+        nonce: felt
     ):
     alloc_locals
 

--- a/contracts/ArgentAccount.cairo
+++ b/contracts/ArgentAccount.cairo
@@ -7,8 +7,7 @@ from starkware.cairo.common.signature import verify_ecdsa_signature
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math import assert_not_zero, assert_le, assert_nn
-from starkware.starknet.common.storage import Storage
-from starkware.starknet.common.syscalls import call_contract
+from starkware.starknet.common.syscalls import call_contract, get_tx_signature
 
 ####################
 # CONSTANTS
@@ -34,25 +33,12 @@ struct Escape:
     member caller: felt
 end
 
-struct Signature:
-    member sig_r: felt
-    member sig_s: felt
-end
-
 ####################
 # STORAGE VARIABLES
 ####################
 
 @storage_var
-func _self_address() -> (res: felt):
-end
-
-@storage_var
 func _current_nonce() -> (res: felt):
-end
-
-@storage_var
-func _initialized() -> (res: felt):
 end
 
 @storage_var
@@ -75,60 +61,50 @@ end
 # EXTERNAL FUNCTIONS
 ####################
 
-@external
-func initialize{
-        storage_ptr: Storage*,
+@constructor
+func constructor{
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr
     } (
         signer: felt,
         guardian: felt,
-        L1_address: felt,
-        self_address: felt
+        L1_address: felt
     ):
-    # check that the contract is not initialized
-    let (initialized) = _initialized.read()
-    assert initialized = 0
-    # check that the signer and self_address are not zero
+    # check that the signer is not zero
     assert_not_zero(signer)
-    assert_not_zero(self_address)
     # initialize the contract
-    _initialized.write(1)
     _signer.write(signer)
     _guardian.write(guardian)
     _L1_address.write(L1_address)
-    _self_address.write(self_address)
     return ()
 end
 
 @external
 func execute{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         ecdsa_ptr: SignatureBuiltin*,
-        syscall_ptr: felt*,
         range_check_ptr
     } (
         to: felt,
         selector: felt,
         calldata_len: felt,
         calldata: felt*,
-        nonce: felt,
-        sig_len: felt,
-        sig: felt*
+        nonce: felt
     ) -> (response : felt):
     alloc_locals
 
-    # cast sig to an array of Signature struct until natively supported by Cairo
-    let (local signatures_len, local signatures) = cast_to_signature(sig_len, sig)
+    # get the signatures
+    let (local sig_len : felt, local sig : felt*) = get_tx_signature()
 
     # validate and bump nonce
     validate_and_bump_nonce(nonce)
 
     # validate signatures
     let (local message_hash) = get_message_hash(to, selector, calldata_len, calldata, nonce)
-    validate_signer_signature(message_hash, signatures, signatures_len, 0)
-    validate_guardian_signature(message_hash, signatures, signatures_len, 1)
+    validate_signer_signature(message_hash, sig, sig_len)
+    validate_guardian_signature(message_hash, sig + 2, sig_len - 2)
 
     # execute call
     let response = call_contract(
@@ -143,7 +119,7 @@ end
 
 @external
 func change_signer{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         ecdsa_ptr: SignatureBuiltin*,
         range_check_ptr
@@ -155,8 +131,8 @@ func change_signer{
     ):
     alloc_locals
 
-    # cast sig to an array of Signature struct until natively supported by Cairo
-    let (local signatures_len, local signatures) = cast_to_signature(sig_len, sig)
+    # get the signatures
+    let (local sig_len : felt, local sig : felt*) = get_tx_signature()
 
     # validate and bump nonce
     validate_and_bump_nonce(nonce)
@@ -166,8 +142,8 @@ func change_signer{
     let calldata: felt* = alloc()
     assert calldata[0] = new_signer
     let (local message_hash) = get_message_hash(to, CHANGE_SIGNER_SELECTOR, 1, calldata, nonce)
-    validate_signer_signature(message_hash, signatures, signatures_len, 0)
-    validate_guardian_signature(message_hash, signatures, signatures_len, 1)
+    validate_signer_signature(message_hash, sig, sig_len)
+    validate_guardian_signature(message_hash, sig + 2, sig_len - 2)
 
     # change signer
     assert_not_zero(new_signer)
@@ -177,7 +153,7 @@ end
 
 @external
 func change_guardian{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         ecdsa_ptr: SignatureBuiltin*,
         range_check_ptr
@@ -189,8 +165,8 @@ func change_guardian{
     ):
     alloc_locals
 
-    # cast sig to an array of Signature struct until natively supported by Cairo
-    let (local signatures_len, local signatures) = cast_to_signature(sig_len, sig)
+    # get the signatures
+    let (local sig_len : felt, local sig : felt*) = get_tx_signature()
 
     # validate and bump nonce
     validate_and_bump_nonce(nonce)
@@ -200,8 +176,8 @@ func change_guardian{
     let calldata: felt* = alloc()
     assert calldata[0] = new_guardian
     let (local message_hash) = get_message_hash(to, CHANGE_GUARDIAN_SELECTOR, 1, calldata, nonce)
-    validate_signer_signature(message_hash, signatures, signatures_len, 0)
-    validate_guardian_signature(message_hash, signatures, signatures_len, 1)
+    validate_signer_signature(message_hash, sig, sig_len)
+    validate_guardian_signature(message_hash, sig + 2, sig_len - 2)
 
     # change guardian
     assert_not_zero(new_guardian)
@@ -211,7 +187,7 @@ end
 
 @external
 func change_L1_address{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         ecdsa_ptr: SignatureBuiltin*,
         range_check_ptr
@@ -223,8 +199,8 @@ func change_L1_address{
     ):
     alloc_locals
 
-    # cast sig to an array of Signature struct until natively supported by Cairo
-    let (local signatures_len, local signatures) = cast_to_signature(sig_len, sig)
+    # get the signatures
+    let (local sig_len : felt, local sig : felt*) = get_tx_signature()
 
     # validate and bump nonce
     validate_and_bump_nonce(nonce)
@@ -234,8 +210,8 @@ func change_L1_address{
     let calldata: felt* = alloc()
     assert calldata[0] = new_L1_address
     let (local message_hash) = get_message_hash(to, CHANGE_L1_ADDRESS_SELECTOR, 1, calldata, nonce)
-    validate_signer_signature(message_hash, signatures, signatures_len, 0)
-    validate_guardian_signature(message_hash, signatures, signatures_len, 1)
+    validate_signer_signature(message_hash, sig, sig_len)
+    validate_guardian_signature(message_hash, sig + 2, sig_len - 2)
 
     # change guardian
     _L1_address.write(new_L1_address)
@@ -244,7 +220,7 @@ end
 
 @external
 func trigger_escape{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         ecdsa_ptr: SignatureBuiltin*,
         range_check_ptr
@@ -256,8 +232,8 @@ func trigger_escape{
     ):
     alloc_locals
 
-    # cast sig to an array of Signature struct until natively supported by Cairo
-    let (local signatures_len, local signatures) = cast_to_signature(sig_len, sig)
+    # get the signatures
+    let (local sig_len : felt, local sig : felt*) = get_tx_signature()
 
     # validate and bump nonce
     validate_and_bump_nonce(nonce)
@@ -280,10 +256,10 @@ func trigger_escape{
     assert calldata[0] = escapor
     let (local message_hash) = get_message_hash(to, TRIGGER_ESCAPE_SELECTOR, 1, calldata, nonce)
     if escapor == signer:
-        validate_signer_signature(message_hash, signatures, signatures_len, 0)
+        validate_signer_signature(message_hash, sig, sig_len)
     else:
         assert escapor = guardian
-        validate_guardian_signature(message_hash, signatures, signatures_len, 0) 
+        validate_guardian_signature(message_hash, sig, sig_len) 
     end
 
     # rebinding ptrs
@@ -298,7 +274,7 @@ end
 
 @external
 func cancel_escape{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         ecdsa_ptr: SignatureBuiltin*,
         range_check_ptr
@@ -309,8 +285,8 @@ func cancel_escape{
     ):
     alloc_locals
 
-    # cast sig to an array of Signature struct until natively supported by Cairo
-    let (local signatures_len, local signatures) = cast_to_signature(sig_len, sig)
+    # get the signatures
+    let (local sig_len : felt, local sig : felt*) = get_tx_signature()
 
     # validate and bump nonce
     validate_and_bump_nonce(nonce)
@@ -323,8 +299,8 @@ func cancel_escape{
     let (to) = _self_address.read()
     let calldata: felt* = alloc()
     let (local message_hash) = get_message_hash(to, CANCEL_ESCAPE_SELECTOR, 0, calldata, nonce)
-    validate_signer_signature(message_hash, signatures, signatures_len, 0)
-    validate_guardian_signature(message_hash, signatures, signatures_len, 1)
+    validate_signer_signature(message_hash, sig, sig_len)
+    validate_guardian_signature(message_hash, sig + 2, sig_len - 2)
 
     # clear escape
     local new_escape: Escape = Escape(0, 0)
@@ -334,7 +310,7 @@ end
 
 @external
 func escape_guardian{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         ecdsa_ptr: SignatureBuiltin*,
         range_check_ptr
@@ -346,8 +322,8 @@ func escape_guardian{
     ):
     alloc_locals
 
-    # cast sig to an array of Signature struct until natively supported by Cairo
-    let (local signatures_len, local signatures) = cast_to_signature(sig_len, sig)
+    # get the signatures
+    let (local sig_len : felt, local sig : felt*) = get_tx_signature()
 
     # validate and bump nonce
     validate_and_bump_nonce(nonce)
@@ -362,7 +338,7 @@ func escape_guardian{
     let calldata: felt* = alloc()
     assert calldata[0] = new_guardian
     let (local message_hash) = get_message_hash(to, ESCAPE_GUARDIAN_SELECTOR, 1, calldata, nonce)
-    validate_signer_signature(message_hash, signatures, signatures_len, 0)
+    validate_signer_signature(message_hash, sig, sig_len)
 
     # clear escape
     local new_escape: Escape = Escape(0, 0)
@@ -377,7 +353,7 @@ end
 
 @external
 func escape_signer{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         ecdsa_ptr: SignatureBuiltin*,
         range_check_ptr
@@ -389,8 +365,8 @@ func escape_signer{
     ):
     alloc_locals
 
-    # cast sig to an array of Signature struct until natively supported by Cairo
-    let (local signatures_len, local signatures) = cast_to_signature(sig_len, sig)
+    # get the signatures
+    let (local sig_len : felt, local sig : felt*) = get_tx_signature()
 
     # validate and bump nonce
     validate_and_bump_nonce(nonce)
@@ -405,7 +381,7 @@ func escape_signer{
     let calldata: felt* = alloc()
     assert calldata[0] = new_signer
     let (local message_hash) = get_message_hash(to, ESCAPE_SIGNER_SELECTOR, 1, calldata, nonce)
-    validate_guardian_signature(message_hash, signatures, signatures_len, 0)
+    validate_guardian_signature(message_hash, sig, sig_len)
 
     # clear escape
     local new_escape: Escape = Escape(0, 0)
@@ -424,10 +400,9 @@ end
 
 @view
 func is_valid_signature{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         ecdsa_ptr: SignatureBuiltin*,
-        syscall_ptr: felt*,
         range_check_ptr
     } (
         hash: felt,
@@ -436,36 +411,24 @@ func is_valid_signature{
     ) -> (magic_value: felt):
     alloc_locals
 
-    # cast sig to an array of Signature struct until natively supported by Cairo
-    let (local signatures_len, local signatures) = cast_to_signature(sig_len, sig)
-
-    validate_signer_signature(hash, signatures, signatures_len, 0)
-    validate_guardian_signature(hash, signatures, signatures_len, 1)
+    validate_signer_signature(hash, sig, sig_len)
+    validate_guardian_signature(hash, sig + 2, sig_len - 2)
     return (magic_value = IS_VALID_SIGNATURE_SELECTOR)
 end
 
 @view
 func get_current_nonce{
-    storage_ptr : Storage*, 
-    pedersen_ptr : HashBuiltin*,
+    syscall_ptr: felt*, 
+    pedersen_ptr: HashBuiltin*,
     range_check_ptr}() -> (nonce: felt):
     let (res) = _current_nonce.read()
     return (nonce=res)
 end
 
 @view
-func get_initialized{
-    storage_ptr : Storage*, 
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr}() -> (initialized: felt):
-    let (res) = _initialized.read()
-    return (initialized=res)
-end
-
-@view
 func get_signer{
-    storage_ptr : Storage*, 
-    pedersen_ptr : HashBuiltin*,
+    syscall_ptr: felt*, 
+    pedersen_ptr: HashBuiltin*,
     range_check_ptr}() -> (signer: felt):
     let (res) = _signer.read()
     return (signer=res)
@@ -473,8 +436,8 @@ end
 
 @view
 func get_guardian{
-    storage_ptr : Storage*, 
-    pedersen_ptr : HashBuiltin*,
+    syscall_ptr: felt*, 
+    pedersen_ptr: HashBuiltin*,
     range_check_ptr}() -> (guardian: felt):
     let (res) = _guardian.read()
     return (guardian=res)
@@ -482,8 +445,8 @@ end
 
 @view
 func get_escape{
-    storage_ptr : Storage*, 
-    pedersen_ptr : HashBuiltin*,
+    syscall_ptr: felt*, 
+    pedersen_ptr: HashBuiltin*,
     range_check_ptr}() -> (active_at: felt, caller: felt):
     let (res) = _escape.read()
     return (active_at=res.active_at, caller=res.caller)
@@ -491,8 +454,8 @@ end
 
 @view
 func get_L1_address{
-    storage_ptr : Storage*, 
-    pedersen_ptr : HashBuiltin*,
+    syscall_ptr: felt*, 
+    pedersen_ptr: HashBuiltin*,
     range_check_ptr}() -> (L1_address: felt):
     let (res) = _L1_address.read()
     return (L1_address=res)
@@ -503,8 +466,8 @@ end
 ####################
 
 func validate_and_bump_nonce{
-        storage_ptr : Storage*, 
-        pedersen_ptr : HashBuiltin*,
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
     } (
         message_nonce: felt
@@ -516,63 +479,68 @@ func validate_and_bump_nonce{
 end
 
 func validate_signer_signature{
-        storage_ptr : Storage*, 
-        pedersen_ptr : HashBuiltin*,
-        ecdsa_ptr : SignatureBuiltin*,
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        ecdsa_ptr: SignatureBuiltin*,
         range_check_ptr
     } (
         message: felt, 
-        signatures: Signature*,
-        signatures_len: felt,
-        position: felt
+        signatures: felt*,
+        signatures_len: felt
     ) -> ():
-    assert_le(position, signatures_len - 1) 
+    assert_nn(signatures_len - 2)
     let (signer) = _signer.read()
     verify_ecdsa_signature(
         message=message,
         public_key=signer,
-        signature_r=signatures[position].sig_r,
-        signature_s=signatures[position].sig_s)
+        signature_r=signatures[0],
+        signature_s=signatures[1])
     return()
 end
 
 func validate_guardian_signature{
-        storage_ptr : Storage*, 
-        pedersen_ptr : HashBuiltin*,
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
         ecdsa_ptr : SignatureBuiltin*,
         range_check_ptr
     } (
         message: felt,
-        signatures: Signature*,
-        signatures_len: felt,
-        position: felt
+        signatures: felt*,
+        signatures_len: felt
     ) -> ():
     let (guardian) = _guardian.read()
     if guardian == 0:
         return()
     else:
-        assert_le(position, signatures_len - 1)
+        assert_nn(signatures_len - 2)
         verify_ecdsa_signature(
             message=message,
             public_key=guardian,
-            signature_r=signatures[position].sig_r,
-            signature_s=signatures[position].sig_s)
+            signature_r=signatures[0],
+            signature_s=signatures[1])
         return()
     end
 end
 
 func get_message_hash{
-    storage_ptr : Storage*, 
-    pedersen_ptr : HashBuiltin*,
-    ecdsa_ptr : SignatureBuiltin*,
-    range_check_ptr}(to: felt, selector: felt, calldata_len: felt, calldata: felt*, nonce: felt) -> (res: felt):
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        ecdsa_ptr: SignatureBuiltin*,
+        range_check_ptr
+    } (
+        to: felt,
+        selector: felt,
+        calldata_len: felt,
+        calldata: felt*,
+        nonce: felt
+    ) -> (res: felt):
     alloc_locals
     let (account) = _self_address.read()
     let (res) = hash2{hash_ptr=pedersen_ptr}(account, to)
     let (res) = hash2{hash_ptr=pedersen_ptr}(res, selector)
     # we need to make `res` local
     # to prevent the reference from being revoked
-    local storage_ptr : Storage* = storage_ptr
+    local syscall_ptr: felt* = syscall_ptr
     local range_check_ptr = range_check_ptr
     local res = res
     let (res_calldata) = hash_calldata(calldata, calldata_len)
@@ -604,13 +572,26 @@ end
 ####################
 
 @storage_var
+func _self_address() -> (res: felt):
+end
+
+@external
+func set_self_address{
+    syscall_ptr: felt*, 
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr}(new_address: felt):
+    _self_address.write(new_address)
+    return ()
+end
+
+@storage_var
 func _block_timestamp() -> (res: felt):
 end
 
 @view
 func get_block_timestamp{
-    storage_ptr : Storage*, 
-    pedersen_ptr : HashBuiltin*,
+    syscall_ptr: felt*, 
+    pedersen_ptr: HashBuiltin*,
     range_check_ptr}() -> (block_timestamp: felt):
     let (res) = _block_timestamp.read()
     return (block_timestamp=res)
@@ -618,21 +599,9 @@ end
 
 @external
 func set_block_timestamp{
-    storage_ptr : Storage*, 
-    pedersen_ptr : HashBuiltin*,
+    syscall_ptr: felt*, 
+    pedersen_ptr: HashBuiltin*,
     range_check_ptr}(new_block_timestamp: felt):
     _block_timestamp.write(new_block_timestamp)
     return ()
-end
-
-func cast_to_signature{
-        range_check_ptr
-    } (
-        array_len: felt,
-        array: felt*
-    ) -> (sig_len: felt, sig: Signature*):
-    let sig_len = array_len / Signature.SIZE
-    assert_nn(sig_len)
-    let sig = cast (array, Signature*)
-    return (sig_len=sig_len,sig=sig)
 end

--- a/contracts/ERC20.cairo
+++ b/contracts/ERC20.cairo
@@ -3,7 +3,6 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
-from starkware.starknet.common.storage import Storage
 from starkware.cairo.common.math import assert_nn_le
 
 #
@@ -37,7 +36,7 @@ end
 
 @view
 func get_total_supply{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr
     } () -> (res: felt):
@@ -47,7 +46,7 @@ end
 
 @view
 func balance_of{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr
     } (user: felt) -> (res: felt):
@@ -57,7 +56,7 @@ end
 
 @view
 func allowance{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr
     } (owner: felt, spender: felt) -> (res: felt):
@@ -71,9 +70,8 @@ end
 
 @external
 func initialize{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
         syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
     } ():
     let (_initialized) = initialized.read()
@@ -86,9 +84,8 @@ func initialize{
 end
 
 func _mint{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
         syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
     } (recipient: felt, amount: felt):
     let (res) = balances.read(user=recipient)
@@ -100,7 +97,7 @@ func _mint{
 end
 
 func _transfer{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr
     } (sender: felt, recipient: felt, amount: felt):
@@ -119,9 +116,8 @@ end
 
 @external
 func mint{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
         syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
     } (recipient: felt, amount: felt):
     _mint(recipient, amount)
@@ -130,9 +126,8 @@ end
 
 @external
 func transfer{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
         syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
     } (recipient: felt, amount: felt):
     let (sender) = get_caller_address()
@@ -142,9 +137,8 @@ end
 
 @external
 func transfer_from{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
         syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
     } (sender: felt, recipient: felt, amount: felt):
     let (caller) = get_caller_address()
@@ -157,9 +151,8 @@ end
 
 @external
 func approve{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
         syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
         range_check_ptr
     } (spender: felt, amount: felt):
     let (caller) = get_caller_address()

--- a/contracts/TestDapp.cairo
+++ b/contracts/TestDapp.cairo
@@ -2,7 +2,6 @@
 %builtins pedersen range_check
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-from starkware.starknet.common.storage import Storage
 from starkware.starknet.common.syscalls import get_caller_address
 
 ####################
@@ -19,7 +18,6 @@ end
 
 @external
 func set_number{
-        storage_ptr: Storage*,
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr
@@ -37,7 +35,7 @@ end
 
 @view
 func get_number{
-        storage_ptr: Storage*,
+        syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr
     }(

--- a/test/argent_account.py
+++ b/test/argent_account.py
@@ -49,152 +49,152 @@ async def test_execute(account_factory):
     await transaction.invoke(signature=signatures)
     assert (await dapp.get_number(account.contract_address).call()).result.number == 47
 
-# @pytest.mark.asyncio
-# async def test_execute_no_guardian(account_factory):
-#     starknet, account = account_factory
-#     account_no_guardian = await deploy(starknet, "contracts/ArgentAccount.cairo")
-#     await account_no_guardian.initialize(signer.public_key, 0, L1_ADDRESS, account_no_guardian.contract_address).invoke()
-#     dapp = await deploy(starknet, "contracts/TestDapp.cairo")
-#     builder = TransactionBuilder(account_no_guardian, signer, 0)
+@pytest.mark.asyncio
+async def test_execute_no_guardian(account_factory):
+    starknet, account = account_factory
+    account_no_guardian = await deploy(starknet, "contracts/ArgentAccount.cairo", [signer.public_key, 0, L1_ADDRESS])
+    await account_no_guardian.set_self_address(account_no_guardian.contract_address).invoke()
+    dapp = await deploy(starknet, "contracts/TestDapp.cairo")
+    builder = TransactionBuilder(account_no_guardian, signer, 0)
 
-#     nonce = await builder.get_current_nonce()
-#     transaction = builder.build_execute_transaction(dapp.contract_address, 'set_number', [47], nonce)
+    nonce = await builder.get_current_nonce()
+    (transaction, signatures) = builder.build_execute_transaction(dapp.contract_address, 'set_number', [47], nonce)
 
-#     assert (await dapp.get_number(account_no_guardian.contract_address).call()).number == 0
-#     await transaction.invoke()
-#     assert (await dapp.get_number(account_no_guardian.contract_address).call()).number == 47
+    assert (await dapp.get_number(account_no_guardian.contract_address).call()).result.number == 0
+    await transaction.invoke(signature=signatures)
+    assert (await dapp.get_number(account_no_guardian.contract_address).call()).result.number == 47
 
-# @pytest.mark.asyncio
-# async def test_change_signer(account_factory):
-#     starknet, account = account_factory
-#     builder = TransactionBuilder(account, signer, guardian)
+@pytest.mark.asyncio
+async def test_change_signer(account_factory):
+    starknet, account = account_factory
+    builder = TransactionBuilder(account, signer, guardian)
 
-#     new_signer = Signer(4444444444)
-#     nonce = await builder.get_current_nonce()
-#     transaction = builder.build_change_signer_transaction(new_signer.public_key, nonce)
+    new_signer = Signer(4444444444)
+    nonce = await builder.get_current_nonce()
+    (transaction, signatures) = builder.build_change_signer_transaction(new_signer.public_key, nonce)
 
-#     assert (await account.get_signer().call()).signer == (signer.public_key)
-#     await transaction.invoke()
-#     assert (await account.get_signer().call()).signer == (new_signer.public_key)
+    assert (await account.get_signer().call()).result.signer == (signer.public_key)
+    await transaction.invoke(signature=signatures)
+    assert (await account.get_signer().call()).result.signer == (new_signer.public_key)
 
-# @pytest.mark.asyncio
-# async def test_change_guardian(account_factory):
-#     starknet, account = account_factory
-#     builder = TransactionBuilder(account, signer, guardian)
+@pytest.mark.asyncio
+async def test_change_guardian(account_factory):
+    starknet, account = account_factory
+    builder = TransactionBuilder(account, signer, guardian)
 
-#     new_guardian = Signer(55555555)
-#     nonce = await builder.get_current_nonce()
-#     transaction = builder.build_change_guardian_transaction(new_guardian.public_key, nonce)
+    new_guardian = Signer(55555555)
+    nonce = await builder.get_current_nonce()
+    (transaction, signatures) = builder.build_change_guardian_transaction(new_guardian.public_key, nonce)
 
-#     assert (await account.get_guardian().call()).guardian == (guardian.public_key)
-#     await transaction.invoke()
-#     assert (await account.get_guardian().call()).guardian == (new_guardian.public_key)
+    assert (await account.get_guardian().call()).result.guardian == (guardian.public_key)
+    await transaction.invoke(signature=signatures)
+    assert (await account.get_guardian().call()).result.guardian == (new_guardian.public_key)
 
-# @pytest.mark.asyncio
-# async def test_change_L1_address(account_factory):
-#     starknet, account = account_factory
-#     builder = TransactionBuilder(account, signer, guardian)
+@pytest.mark.asyncio
+async def test_change_L1_address(account_factory):
+    starknet, account = account_factory
+    builder = TransactionBuilder(account, signer, guardian)
 
-#     new_L1_address = 0xa1a1224e9071470ab12a8df7626d4fe7789a039d
-#     nonce = await builder.get_current_nonce()
-#     transaction = builder.build_change_L1_address_transaction(new_L1_address, nonce)
+    new_L1_address = 0xa1a1224e9071470ab12a8df7626d4fe7789a039d
+    nonce = await builder.get_current_nonce()
+    (transaction, signatures) = builder.build_change_L1_address_transaction(new_L1_address, nonce)
 
-#     assert (await account.get_L1_address().call()).L1_address == (L1_ADDRESS)
-#     await transaction.invoke()
-#     assert (await account.get_L1_address().call()).L1_address == (new_L1_address)
+    assert (await account.get_L1_address().call()).result.L1_address == (L1_ADDRESS)
+    await transaction.invoke(signature=signatures)
+    assert (await account.get_L1_address().call()).result.L1_address == (new_L1_address)
 
-# @pytest.mark.asyncio
-# async def test_trigger_escape_by_signer(account_factory):
-#     starknet, account = account_factory
-#     builder = TransactionBuilder(account, signer, guardian)
+@pytest.mark.asyncio
+async def test_trigger_escape_by_signer(account_factory):
+    starknet, account = account_factory
+    builder = TransactionBuilder(account, signer, guardian)
 
-#     await builder.set_block_timestamp(121)
+    await builder.set_block_timestamp(121)
 
-#     nonce = await builder.get_current_nonce()
-#     transaction = builder.build_trigger_escape_transaction(signer, nonce)
-#     escape = await account.get_escape().call()
-#     assert (escape.active_at == 0 and escape.caller == 0)
-#     await transaction.invoke()
-#     escape = await account.get_escape().call()
-#     assert (escape.active_at == (121 + ESCAPE_SECURITY_PERIOD) and escape.caller == signer.public_key)
+    nonce = await builder.get_current_nonce()
+    (transaction, signatures) = builder.build_trigger_escape_transaction(signer, nonce)
+    escape = (await account.get_escape().call()).result
+    assert (escape.active_at == 0 and escape.caller == 0)
+    await transaction.invoke(signature=signatures)
+    escape = (await account.get_escape().call()).result
+    assert (escape.active_at == (121 + ESCAPE_SECURITY_PERIOD) and escape.caller == signer.public_key)
 
-# @pytest.mark.asyncio
-# async def test_trigger_escape_by_guardian(account_factory):
-#     starknet, account = account_factory
-#     builder = TransactionBuilder(account, signer, guardian)
+@pytest.mark.asyncio
+async def test_trigger_escape_by_guardian(account_factory):
+    starknet, account = account_factory
+    builder = TransactionBuilder(account, signer, guardian)
 
-#     await builder.set_block_timestamp(127)
+    await builder.set_block_timestamp(127)
 
-#     nonce = await builder.get_current_nonce()
-#     transaction = builder.build_trigger_escape_transaction(guardian, nonce)
-#     escape = await account.get_escape().call()
-#     assert (escape.active_at == 0 and escape.caller == 0)
-#     await transaction.invoke()
-#     escape = await account.get_escape().call()
-#     assert (escape.active_at == (127 + ESCAPE_SECURITY_PERIOD) and escape.caller == guardian.public_key)
+    nonce = await builder.get_current_nonce()
+    (transaction, signatures) = builder.build_trigger_escape_transaction(guardian, nonce)
+    escape = (await account.get_escape().call()).result
+    assert (escape.active_at == 0 and escape.caller == 0)
+    await transaction.invoke(signature=signatures)
+    escape = (await account.get_escape().call()).result
+    assert (escape.active_at == (127 + ESCAPE_SECURITY_PERIOD) and escape.caller == guardian.public_key)
 
-# @pytest.mark.asyncio
-# async def test_escape_guardian(account_factory):
-#     starknet, account = account_factory
-#     builder = TransactionBuilder(account, signer, guardian)
+@pytest.mark.asyncio
+async def test_escape_guardian(account_factory):
+    starknet, account = account_factory
+    builder = TransactionBuilder(account, signer, guardian)
 
-#     await builder.set_block_timestamp(121)
+    await builder.set_block_timestamp(121)
 
-#     # trigger escape
-#     nonce = await builder.get_current_nonce()
-#     transaction = builder.build_trigger_escape_transaction(signer, nonce)
-#     await transaction.invoke()
-#     escape = await account.get_escape().call()
-#     assert (escape.active_at == (121 + ESCAPE_SECURITY_PERIOD) and escape.caller == signer.public_key)
+    # trigger escape
+    nonce = await builder.get_current_nonce()
+    (transaction, signatures) = builder.build_trigger_escape_transaction(signer, nonce)
+    await transaction.invoke(signature=signatures)
+    escape = (await account.get_escape().call()).result
+    assert (escape.active_at == (121 + ESCAPE_SECURITY_PERIOD) and escape.caller == signer.public_key)
 
-#     await builder.set_block_timestamp(121 + ESCAPE_SECURITY_PERIOD)
+    await builder.set_block_timestamp(121 + ESCAPE_SECURITY_PERIOD)
 
-#     # escape guardian
-#     new_guardian = Signer(55555555)
-#     nonce = await builder.get_current_nonce()
-#     transaction = builder.build_escape_guardian_transaction(new_guardian, nonce)
+    # escape guardian
+    new_guardian = Signer(55555555)
+    nonce = await builder.get_current_nonce()
+    (transaction, signatures) = builder.build_escape_guardian_transaction(new_guardian, nonce)
     
-#     assert (await account.get_guardian().call()).guardian == (guardian.public_key)
-#     await transaction.invoke()
-#     assert (await account.get_guardian().call()).guardian == (new_guardian.public_key)
-#     # escape should be cleared
-#     escape = await account.get_escape().call()
-#     assert (escape.active_at == 0 and escape.caller == 0)
+    assert (await account.get_guardian().call()).result.guardian == (guardian.public_key)
+    await transaction.invoke(signature=signatures)
+    assert (await account.get_guardian().call()).result.guardian == (new_guardian.public_key)
+    # escape should be cleared
+    escape = (await account.get_escape().call()).result
+    assert (escape.active_at == 0 and escape.caller == 0)
 
-# @pytest.mark.asyncio
-# async def test_escape_signer(account_factory):
-#     starknet, account = account_factory
-#     builder = TransactionBuilder(account, signer, guardian)
+@pytest.mark.asyncio
+async def test_escape_signer(account_factory):
+    starknet, account = account_factory
+    builder = TransactionBuilder(account, signer, guardian)
 
-#     await builder.set_block_timestamp(121)
+    await builder.set_block_timestamp(121)
 
-#     # trigger escape
-#     nonce = await builder.get_current_nonce()
-#     transaction = builder.build_trigger_escape_transaction(guardian, nonce)
-#     await transaction.invoke()
-#     escape = await account.get_escape().call()
-#     assert (escape.active_at == (121 + ESCAPE_SECURITY_PERIOD) and escape.caller == guardian.public_key)
+    # trigger escape
+    nonce = await builder.get_current_nonce()
+    (transaction, signatures) = builder.build_trigger_escape_transaction(guardian, nonce)
+    await transaction.invoke(signature=signatures)
+    escape = (await account.get_escape().call()).result
+    assert (escape.active_at == (121 + ESCAPE_SECURITY_PERIOD) and escape.caller == guardian.public_key)
 
-#     await builder.set_block_timestamp(121 + ESCAPE_SECURITY_PERIOD + 1)
+    await builder.set_block_timestamp(121 + ESCAPE_SECURITY_PERIOD + 1)
 
-#     # escape signer
-#     new_signer = Signer(555554675)
-#     nonce = await builder.get_current_nonce()
-#     transaction = builder.build_escape_signer_transaction(new_signer, nonce)
+    # escape signer
+    new_signer = Signer(555554675)
+    nonce = await builder.get_current_nonce()
+    (transaction, signatures) = builder.build_escape_signer_transaction(new_signer, nonce)
     
-#     assert (await account.get_signer().call()).signer == (signer.public_key)
-#     await transaction.invoke()
-#     assert (await account.get_signer().call()).signer == (new_signer.public_key)
-#     # escape should be cleared
-#     escape = await account.get_escape().call()
-#     assert (escape.active_at == 0 and escape.caller == 0)
+    assert (await account.get_signer().call()).result.signer == (signer.public_key)
+    await transaction.invoke(signature=signatures)
+    assert (await account.get_signer().call()).result.signer == (new_signer.public_key)
+    # escape should be cleared
+    escape = (await account.get_escape().call()).result
+    assert (escape.active_at == 0 and escape.caller == 0)
 
-# @pytest.mark.asyncio
-# async def test_is_valid_signature(account_factory):
-#     starknet, account = account_factory
-#     builder = TransactionBuilder(account, signer, guardian)
+@pytest.mark.asyncio
+async def test_is_valid_signature(account_factory):
+    starknet, account = account_factory
+    builder = TransactionBuilder(account, signer, guardian)
 
-#     hash = 1283225199545181604979924458180358646374088657288769423115053097913173815464
-#     transaction = builder.build_is_valid_signature_transaction(hash)
-#     res = await transaction.call()
-#     assert (res.magic_value == MAGIC_VALUE)
+    hash = 1283225199545181604979924458180358646374088657288769423115053097913173815464
+    transaction = builder.build_is_valid_signature_transaction(hash)
+    res = (await transaction.call()).result
+    assert (res.magic_value == MAGIC_VALUE)

--- a/test/utils/TransactionBuilder.py
+++ b/test/utils/TransactionBuilder.py
@@ -23,39 +23,51 @@ class TransactionBuilder():
         message_hash = hash_message(self.account.contract_address, self.account.contract_address, selector, [new_signer], nonce)
         signer_sig = self.signer.sign(message_hash)
         guardian_sig = self.guardian.sign(message_hash)
-        return self.account.change_signer(new_signer, nonce, [signer_sig[0], signer_sig[1], guardian_sig[0], guardian_sig[1]])
+        signatures = [signer_sig[0], signer_sig[1], guardian_sig[0], guardian_sig[1]]
+        transaction = self.account.change_signer(new_signer, nonce)
+        return (transaction, signatures)
 
     def build_change_guardian_transaction(self, new_guardian, nonce):
         selector = get_selector_from_name('change_guardian')
         message_hash = hash_message(self.account.contract_address, self.account.contract_address, selector, [new_guardian], nonce)
         signer_sig = self.signer.sign(message_hash)
         guardian_sig = self.guardian.sign(message_hash)
-        return self.account.change_guardian(new_guardian, nonce, [signer_sig[0], signer_sig[1], guardian_sig[0], guardian_sig[1]])
+        signatures = [signer_sig[0], signer_sig[1], guardian_sig[0], guardian_sig[1]]
+        transaction =  self.account.change_guardian(new_guardian, nonce)
+        return (transaction, signatures)
         
     def build_change_L1_address_transaction(self, new_L1_address, nonce):
         selector = get_selector_from_name('change_L1_address')
         message_hash = hash_message(self.account.contract_address, self.account.contract_address, selector, [new_L1_address], nonce)
         signer_sig = self.signer.sign(message_hash)
         guardian_sig = self.guardian.sign(message_hash)
-        return self.account.change_L1_address(new_L1_address, nonce, [signer_sig[0], signer_sig[1], guardian_sig[0], guardian_sig[1]])
+        signatures = [signer_sig[0], signer_sig[1], guardian_sig[0], guardian_sig[1]]
+        transaction = self.account.change_L1_address(new_L1_address, nonce)
+        return (transaction, signatures)
 
     def build_trigger_escape_transaction(self, escapor_signer, nonce):
         selector = get_selector_from_name('trigger_escape')
         message_hash = hash_message(self.account.contract_address, self.account.contract_address, selector, [escapor_signer.public_key], nonce)
-        sig = escapor_signer.sign(message_hash)
-        return self.account.trigger_escape(escapor_signer.public_key, nonce, [sig[0], sig[1]])
+        signer_sig = escapor_signer.sign(message_hash)
+        signatures = [signer_sig[0], signer_sig[1]]
+        transaction = self.account.trigger_escape(escapor_signer.public_key, nonce)
+        return (transaction, signatures)
 
     def build_escape_guardian_transaction(self, new_guardian, nonce):
         selector = get_selector_from_name('escape_guardian')
         message_hash = hash_message(self.account.contract_address, self.account.contract_address, selector, [new_guardian.public_key], nonce)
-        sig = self.signer.sign(message_hash)
-        return self.account.escape_guardian(new_guardian.public_key, nonce, [sig[0], sig[1]])
+        signer_sig = self.signer.sign(message_hash)
+        signatures = [signer_sig[0], signer_sig[1]]
+        transaction = self.account.escape_guardian(new_guardian.public_key, nonce)
+        return (transaction, signatures)
 
     def build_escape_signer_transaction(self, new_signer, nonce):
         selector = get_selector_from_name('escape_signer')
         message_hash = hash_message(self.account.contract_address, self.account.contract_address, selector, [new_signer.public_key], nonce)
-        sig = self.guardian.sign(message_hash)
-        return self.account.escape_signer(new_signer.public_key, nonce, [sig[0], sig[1]])
+        guardian_sig = self.guardian.sign(message_hash)
+        signatures = [guardian_sig[0], guardian_sig[1]]
+        transaction = self.account.escape_signer(new_signer.public_key, nonce)
+        return (transaction, signatures)
 
     def build_is_valid_signature_transaction(self, hash):
         sig_signer = self.signer.sign(hash)

--- a/test/utils/TransactionBuilder.py
+++ b/test/utils/TransactionBuilder.py
@@ -16,7 +16,7 @@ class TransactionBuilder():
             guardian_sig = self.guardian.sign(message_hash)
             signatures.append(guardian_sig[0])
             signatures.append(guardian_sig[1])
-        return self.account.execute(to, selector, calldata, nonce, signatures)
+        return (self.account.execute(to, selector, calldata, nonce), signatures)
 
     def build_change_signer_transaction(self, new_signer, nonce):
         selector = get_selector_from_name('change_signer')
@@ -63,7 +63,7 @@ class TransactionBuilder():
         return self.account.is_valid_signature(hash, [sig_signer[0], sig_signer[1], sig_guardian[0], sig_guardian[1]])
 
     async def get_current_nonce(self):
-        return (await self.account.get_current_nonce().call()).nonce
+        return (await self.account.get_current_nonce().call()).result.nonce
 
     async def set_block_timestamp(self, timestamp):
         await self.account.set_block_timestamp(timestamp).invoke()

--- a/test/utils/deploy.py
+++ b/test/utils/deploy.py
@@ -3,7 +3,7 @@ from starkware.starknet.testing.contract import StarknetContract
 from starkware.starknet.compiler.compile import compile_starknet_files
 
 
-async def deploy(starknet, path):
+async def deploy(starknet, path, params=[]):
     contract_definition = compile_starknet_files([path], debug_info=True)
-    deployed_contract = await starknet.deploy(contract_def=contract_definition)
+    deployed_contract = await starknet.deploy(contract_def=contract_definition,constructor_calldata=params)
     return deployed_contract


### PR DESCRIPTION
- replaced the `init` method with the newly introduced `constructor`
- moved signatures out of `calldata`
- cleaning 