### PR TITLE
Multicall

### DIFF
--- a/contracts/Multicall.cairo
+++ b/contracts/Multicall.cairo
@@ -1,0 +1,81 @@
+%lang starknet
+%builtins pedersen range_check ecdsa
+
+from starkware.starknet.common.syscalls import call_contract
+from starkware.cairo.common.alloc import alloc
+
+#########################################################################
+# The Multicall contract can call an array of view methods on different
+# contracts and return the aggregate response as an array.
+# Each view method being called must retrun a single felt for the 
+# multicall to succeed.  
+#########################################################################
+
+@view
+func multicall{
+        syscall_ptr: felt*,
+        range_check_ptr
+    } (
+        contract_len: felt,
+        contract: felt*,
+        selector_len: felt,
+        selector: felt*,
+        offset_len: felt,
+        offset: felt*,
+        calldata_len: felt,
+        calldata: felt*
+    ) -> (result_len: felt, result: felt*):
+    alloc_locals
+
+    assert contract_len = selector_len
+    assert contract_len = offset_len
+
+    let (local result : felt*) = alloc()
+    call_loop(
+        num_calls=contract_len,
+        contract=contract,
+        selector=selector,
+        offset=offset,
+        calldata=calldata,
+        result=result
+    )
+
+    return (result_len=contract_len, result=result)
+
+end
+
+func call_loop{
+        syscall_ptr: felt*,
+        range_check_ptr
+    } (
+        num_calls: felt,
+        contract: felt*,
+        selector: felt*,
+        offset: felt*,
+        calldata: felt*,
+        result: felt*
+    ) -> ():
+
+    if num_calls == 0: 
+        return ()
+    end
+
+    let response = call_contract(
+        contract_address=[contract],
+        function_selector=[selector],
+        calldata_size=[offset],
+        calldata=calldata
+    )
+
+    assert response.retdata_size = 1
+    assert [result] = [response.retdata]
+
+    return call_loop(
+        num_calls=num_calls - 1,
+        contract=contract + 1,
+        selector=selector + 1,
+        offset=offset + 1,
+        calldata=calldata + [offset],
+        result=result + 1
+    )
+end

--- a/test/multicall.py
+++ b/test/multicall.py
@@ -1,0 +1,38 @@
+import pytest
+import asyncio
+from starkware.starknet.testing.starknet import Starknet
+from starkware.starknet.testing.objects import StarknetContractCall
+from starkware.starknet.public.abi import get_selector_from_name
+from utils.deploy import deploy
+
+user1 = 0x69221ff9023c4d7ba9123f0f9c32634c23fc5776d86657f464ecb51fd811445
+user2 = 0x72648c3b1953572d2c4395a610f18b83cca14fa4d1ba10fc4484431fd463e5c
+
+@pytest.fixture(scope='module')
+def event_loop():
+    return asyncio.new_event_loop()
+
+@pytest.fixture(scope='module')
+async def get_starknet():
+    starknet = await Starknet.empty()
+    return starknet
+
+@pytest.mark.asyncio
+async def test_multicall(get_starknet):
+    starknet = get_starknet
+    multicall = await deploy(starknet, "contracts/Multicall.cairo")
+    erc20_1 = await deploy(starknet, "contracts/ERC20.cairo")
+    erc20_2 = await deploy(starknet, "contracts/ERC20.cairo")
+
+    await erc20_1.mint(user1, 100).invoke()
+    await erc20_2.mint(user2, 200).invoke()
+
+    contracts = [erc20_1.contract_address, erc20_1.contract_address, erc20_2.contract_address]
+    selectors = [get_selector_from_name('decimals'), get_selector_from_name('balance_of'), get_selector_from_name('balance_of')]
+    offsets = [0, 1, 1]
+    calldata = [user1, user2]
+
+    response = await multicall.multicall(contracts, selectors, offsets, calldata).call()
+    assert response.result.result[0] == 18
+    assert response.result.result[1] == 100
+    assert response.result.result[2] == 200


### PR DESCRIPTION
Addition of the Multicall contract to call an array of view methods on different contracts and return the aggregate response as an array.

Each view method being called must return a single felt for the multicall to succeed.  