### PR TITLE
Clean multicall

### DIFF
--- a/contracts/Multicall.cairo
+++ b/contracts/Multicall.cairo
@@ -1,26 +1,26 @@
 %lang starknet
 
-from starkware.starknet.common.syscalls import call_contract
+from starkware.starknet.common.syscalls import call_contract, get_block_number
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.memcpy import memcpy
 
 
 #########################################################################
 # The Multicall contract can call an array of view methods on different
-# contracts and return the aggregate responses as an array.
+# contracts and return the aggregate response as an array.
 # E.g.
 # Input: [to_1, selector_1, data_1_len, data_1, ..., to_N, selector_N, data_N_len, data_N]
 # Output: [result_1 + .... + result_N]
 #########################################################################
 
 @view
-func multicall{
+func aggregate{
         syscall_ptr: felt*,
         range_check_ptr
     } (
         calls_len: felt,
         calls: felt*
-    ) -> (result_len: felt, result: felt*):
+    ) -> (block_number: felt, result_len: felt, result: felt*):
     alloc_locals
 
     let (result : felt*) = alloc()
@@ -29,8 +29,9 @@ func multicall{
         calls=calls,
         result=result
     )
+    let (block_number) = get_block_number()
 
-    return (result_len=result_len, result=result)
+    return (block_number=block_number, result_len=result_len, result=result)
 
 end
 

--- a/test/multicall.py
+++ b/test/multicall.py
@@ -23,12 +23,12 @@ async def test_multicall(get_starknet):
     erc20_1 = await deploy(starknet, "contracts/lib/ERC20.cairo", [str_to_felt('token1'), str_to_felt('T1'), user1])
     erc20_2 = await deploy(starknet, "contracts/lib/ERC20.cairo", [str_to_felt('token2'), str_to_felt('T2'), user2])
 
-    response = await multicall.multicall([
+    response = await multicall.aggregate([
         erc20_1.contract_address, get_selector_from_name('decimals'), 0,
         erc20_1.contract_address, get_selector_from_name('balanceOf'), 1, user1,
         erc20_2.contract_address, get_selector_from_name('balanceOf'), 1, user2
     ]).call()
-    print(response.result)
+
     assert response.result.result[0] == 18
     assert response.result.result[1] == 1000
     assert response.result.result[3] == 1000


### PR DESCRIPTION
- Renamed `Call_Input` into `MCall`
- Updated `Multicall.cairo` to align with the Solidity implementation of MakerDAO