### PR TITLE
Fix imports for 0.8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cairo-lang>=0.8.0
+cairo-lang>=0.8.1
 cairo-nile>=0.5.0
 pytest
 pytest-asyncio

--- a/test/address_registry.py
+++ b/test/address_registry.py
@@ -2,13 +2,13 @@ import pytest
 import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils.Signer import Signer
-from utils.deploy import deploy
+from utils.utilities import deploy, str_to_felt
 from utils.TransactionSender import TransactionSender
 
 signer = Signer(123456789987654321)
 guardian = Signer(456789987654321123)
 
-VERSION = 206933405232 # '0.1.0' = 30 2E 31 2E 30 = 0x302E312E30 = 206933405232
+VERSION = str_to_felt('0.2.1')
 L1_ADDRESS = 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
 
 @pytest.fixture(scope='module')
@@ -23,7 +23,8 @@ async def get_starknet():
 @pytest.fixture
 async def account_factory(get_starknet):
     starknet = get_starknet
-    account = await deploy(starknet, "contracts/ArgentAccount.cairo", [signer.public_key, guardian.public_key])
+    account = await deploy(starknet, "contracts/ArgentAccount.cairo")
+    await account.initialize(signer.public_key, guardian.public_key).invoke()
     return account
 
 @pytest.fixture
@@ -47,6 +48,6 @@ async def test_setup_registry(account_factory, registry_factory):
 
     assert (await registry.get_L1_address(account.contract_address).call()).result.res == 0
 
-    await sender.send_transaction(registry.contract_address, 'set_L1_address', [L1_ADDRESS], [signer, guardian])
+    await sender.send_transaction([(registry.contract_address, 'set_L1_address', [L1_ADDRESS])], [signer, guardian])
 
     assert (await registry.get_L1_address(account.contract_address).call()).result.res == L1_ADDRESS

--- a/test/argent_account.py
+++ b/test/argent_account.py
@@ -4,7 +4,7 @@ import logging
 from starkware.starknet.testing.starknet import Starknet
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
-from starkware.starknet.business_logic.state import BlockInfo
+from starkware.starknet.business_logic.state.state import BlockInfo
 from starkware.starknet.compiler.compile import get_selector_from_name
 from utils.Signer import Signer
 from utils.utilities import deploy, assert_revert, str_to_felt, assert_event_emmited
@@ -39,7 +39,7 @@ async def get_starknet():
     return starknet
 
 def update_starknet_block(starknet, block_number=1, block_timestamp=DEFAULT_TIMESTAMP):
-    starknet.state.state.block_info = BlockInfo(block_number=block_number, block_timestamp=block_timestamp)
+    starknet.state.state.block_info = BlockInfo(block_number=block_number, block_timestamp=block_timestamp, gas_price = 0)
 
 def reset_starknet_block(starknet):
     update_starknet_block(starknet=starknet)

--- a/test/argent_account.py
+++ b/test/argent_account.py
@@ -36,7 +36,7 @@ async def get_starknet():
     return starknet
 
 def update_starknet_block(starknet, block_number=1, block_timestamp=DEFAULT_TIMESTAMP):
-    starknet.state.state.block_info = BlockInfo(block_number=block_number, block_timestamp=block_timestamp, gas_price = 0)
+    starknet.state.state.block_info = BlockInfo(block_number=block_number, block_timestamp=block_timestamp, gas_price=0)
 
 def reset_starknet_block(starknet):
     update_starknet_block(starknet=starknet)

--- a/test/argent_account.py
+++ b/test/argent_account.py
@@ -2,10 +2,7 @@ import pytest
 import asyncio
 import logging
 from starkware.starknet.testing.starknet import Starknet
-from starkware.starkware_utils.error_handling import StarkException
-from starkware.starknet.definitions.error_codes import StarknetErrorCode
 from starkware.starknet.business_logic.state.state import BlockInfo
-from starkware.starknet.compiler.compile import get_selector_from_name
 from utils.Signer import Signer
 from utils.utilities import deploy, assert_revert, str_to_felt, assert_event_emmited
 from utils.TransactionSender import TransactionSender

--- a/test/multicall.py
+++ b/test/multicall.py
@@ -2,7 +2,7 @@ import pytest
 import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from starkware.starknet.public.abi import get_selector_from_name
-from utils.utilities import deploy, str_to_felt, uint
+from utils.utilities import deploy, str_to_felt
 
 user1 = 0x69221ff9023c4d7ba9123f0f9c32634c23fc5776d86657f464ecb51fd811445
 user2 = 0x72648c3b1953572d2c4395a610f18b83cca14fa4d1ba10fc4484431fd463e5c

--- a/test/proxy.py
+++ b/test/proxy.py
@@ -1,7 +1,6 @@
 import pytest
 import asyncio
 from starkware.starknet.testing.starknet import Starknet
-from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
 from utils.Signer import Signer
 from utils.utilities import deploy, deploy_proxy, assert_revert, str_to_felt, assert_event_emmited

--- a/test/struct_hash.py
+++ b/test/struct_hash.py
@@ -1,7 +1,7 @@
 import pytest
 import asyncio
 from starkware.starknet.testing.starknet import Starknet
-from utils.deploy import deploy
+from utils.utilities import deploy
 
 user1 = 0x69221ff9023c4d7ba9123f0f9c32634c23fc5776d86657f464ecb51fd811445
 user2 = 0x72648c3b1953572d2c4395a610f18b83cca14fa4d1ba10fc4484431fd463e5c

--- a/test/utils/TransactionSender.py
+++ b/test/utils/TransactionSender.py
@@ -1,7 +1,7 @@
 from starkware.starknet.public.abi import get_selector_from_name
 from starkware.cairo.common.hash_state import compute_hash_on_elements
 from starkware.starknet.definitions.general_config import StarknetChainId
-from starkware.starknet.core.os.transaction_hash import calculate_transaction_hash_common, TransactionHashPrefix
+from starkware.starknet.core.os.transaction_hash.transaction_hash import calculate_transaction_hash_common, TransactionHashPrefix
 import logging
 from utils.utilities import str_to_felt
 

--- a/test/utils/TransactionSender.py
+++ b/test/utils/TransactionSender.py
@@ -1,5 +1,4 @@
 from starkware.starknet.public.abi import get_selector_from_name
-from starkware.cairo.common.hash_state import compute_hash_on_elements
 from starkware.starknet.definitions.general_config import StarknetChainId
 from starkware.starknet.core.os.transaction_hash.transaction_hash import calculate_transaction_hash_common, TransactionHashPrefix
 import logging

--- a/test/utils/utilities.py
+++ b/test/utils/utilities.py
@@ -3,7 +3,7 @@ from starkware.starknet.testing.contract import StarknetContract
 from starkware.starknet.compiler.compile import compile_starknet_files
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
-from starkware.starknet.business_logic.transaction_execution_objects import Event
+from starkware.starknet.business_logic.execution.objects import Event
 from starkware.starknet.compiler.compile import get_selector_from_name
 
 def str_to_felt(text):


### PR DESCRIPTION
Update the import for `BlockInfo` and `Event` used in tests.