### PR TITLE
Use common.bool true and false

### DIFF
--- a/contracts/ArgentAccount.cairo
+++ b/contracts/ArgentAccount.cairo
@@ -8,6 +8,7 @@ from starkware.cairo.common.math import assert_not_zero, assert_le, assert_nn
 from starkware.starknet.common.syscalls import (
     call_contract, get_tx_info, get_contract_address, get_caller_address, get_block_timestamp
 )
+from starkware.cairo.common.bool import {TRUE, FALSE}
 
 from contracts.Upgradable import _set_implementation
 
@@ -37,9 +38,6 @@ const ESCAPE_TYPE_GUARDIAN = 1
 const ESCAPE_TYPE_SIGNER = 2
 
 const ERC165_ACCOUNT_INTERFACE = 0xf10dbd44
-
-const TRUE = 1
-const FALSE = 0
 
 ####################
 # STRUCTS

--- a/contracts/ArgentAccount.cairo
+++ b/contracts/ArgentAccount.cairo
@@ -8,7 +8,7 @@ from starkware.cairo.common.math import assert_not_zero, assert_le, assert_nn
 from starkware.starknet.common.syscalls import (
     call_contract, get_tx_info, get_contract_address, get_caller_address, get_block_timestamp
 )
-from starkware.cairo.common.bool import {TRUE, FALSE}
+from starkware.cairo.common.bool import (TRUE, FALSE)
 
 from contracts.Upgradable import _set_implementation
 

--- a/contracts/lib/ERC20.cairo
+++ b/contracts/lib/ERC20.cairo
@@ -6,7 +6,7 @@ from starkware.cairo.common.math import assert_not_zero
 from starkware.cairo.common.uint256 import (
     Uint256, uint256_add, uint256_sub, uint256_le, uint256_lt, uint256_check
 )
-from starkware.cairo.common.bool import {TRUE, FALSE}
+from starkware.cairo.common.bool import (TRUE, FALSE)
 
 #
 # Storage

--- a/contracts/lib/ERC20.cairo
+++ b/contracts/lib/ERC20.cairo
@@ -6,6 +6,7 @@ from starkware.cairo.common.math import assert_not_zero
 from starkware.cairo.common.uint256 import (
     Uint256, uint256_add, uint256_sub, uint256_le, uint256_lt, uint256_check
 )
+from starkware.cairo.common.bool import {TRUE, FALSE}
 
 #
 # Storage
@@ -135,8 +136,7 @@ func transfer{
     let (sender) = get_caller_address()
     _transfer(sender, recipient, amount)
 
-    # Cairo equivalent to 'return (true)'
-    return (1)
+    return (TRUE)
 end
 
 @external
@@ -163,8 +163,7 @@ func transferFrom{
     let (new_allowance: Uint256) = uint256_sub(caller_allowance, amount)
     allowances.write(sender, caller, new_allowance)
 
-    # Cairo equivalent to 'return (true)'
-    return (1)
+    return (TRUE)
 end
 
 @external
@@ -176,8 +175,7 @@ func approve{
     let (caller) = get_caller_address()
     _approve(caller, spender, amount)
 
-    # Cairo equivalent to 'return (true)'
-    return (1)
+    return (TRUE)
 end
 
 @external
@@ -197,8 +195,7 @@ func increaseAllowance{
 
     _approve(caller, spender, new_allowance)
 
-    # Cairo equivalent to 'return (true)'
-    return (1)
+    return (TRUE)
 end
 
 @external
@@ -219,8 +216,7 @@ func decreaseAllowance{
 
     _approve(caller, spender, new_allowance)
 
-    # Cairo equivalent to 'return (true)'
-    return (1)
+    return (TRUE)
 end
 
 #


### PR DESCRIPTION
This PR removes the custom definition of `TRUE` and `FALSE` and rather imports them from https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/bool.cairo 

It also removes all the previous comments that specified that `1` was equal to `true` (legacy comments I think :))