### PR TITLE
Deploy contracts from the account

### DIFF
--- a/contracts/test/TestDapp2.cairo
+++ b/contracts/test/TestDapp2.cairo
@@ -1,0 +1,54 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+
+####################
+# STORAGE VARIABLES
+####################
+
+@storage_var
+func stored_number() -> (res: felt):
+end
+
+####################
+# EXTERNAL FUNCTIONS
+####################
+
+@constructor
+func constructor{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        number: felt
+    ):
+    stored_number.write(number)
+    return ()
+end
+
+@external
+func set_number{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        number: felt
+    ):
+    stored_number.write(number)
+    return ()
+end
+
+####################
+# VIEW FUNCTIONS
+####################
+
+@view
+func get_number{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    } () -> (number: felt):
+    let (number) = stored_number.read()
+    return (number=number)
+end

--- a/test/deploy_contract.py
+++ b/test/deploy_contract.py
@@ -1,0 +1,46 @@
+import pytest
+import asyncio
+import logging
+from starkware.starknet.testing.starknet import Starknet
+from starkware.starknet.business_logic.state.state import BlockInfo
+from utils.Signer import Signer
+from utils.utilities import deploy, declare, assert_revert, str_to_felt, assert_event_emmited
+from utils.TransactionSender import TransactionSender
+
+signer = Signer(123456789987654321)
+
+@pytest.fixture(scope='module')
+def event_loop():
+    return asyncio.new_event_loop()
+
+@pytest.fixture(scope='module')
+async def get_starknet():
+    starknet = await Starknet.empty()
+    return starknet
+
+@pytest.fixture
+async def account_factory(get_starknet):
+    starknet = get_starknet
+    account = await deploy(starknet, "contracts/ArgentAccount.cairo")
+    await account.initialize(signer.public_key, 0).invoke()
+    return account
+
+@pytest.mark.asyncio
+async def test_deploy_contract(get_starknet, account_factory):
+    starknet = get_starknet
+    account = account_factory
+    sender = TransactionSender(account)
+
+    class_hash = (await declare(starknet, "contracts/test/TestDapp.cairo")).class_hash
+
+    # deploy dapp contract
+    constructor_args = []
+    tx_exec_info = await sender.send_transaction([(account.contract_address, 'deploy_contract', [class_hash, 0, constructor_args])], [signer])
+
+    event = assert_event_emmited(
+        tx_exec_info,
+        from_address=account.contract_address,
+        name='contract_deployed'
+    )
+
+    logging.INFO(event)

--- a/test/utils/utilities.py
+++ b/test/utils/utilities.py
@@ -38,7 +38,14 @@ def assert_event_emmited(tx_exec_info, from_address, name, data = []):
     )
     assert event in raw_events
 
-    return event
+def first_event_emitted(tx_exec_info, from_address, name):
+    raw_events = [Event(from_address=event.from_address, keys=event.keys, data=[]) for event in tx_exec_info.raw_events]
+    event = Event(from_address=from_address, keys=[get_selector_from_name(name)], data=[])
+    
+    index = raw_events.index(event)
+
+    return tx_exec_info.raw_events[index]
+
 
 contract_classes = {}
 

--- a/test/utils/utilities.py
+++ b/test/utils/utilities.py
@@ -31,11 +31,14 @@ def assert_event_emmited(tx_exec_info, from_address, name, data = []):
     else: 
         raw_events = tx_exec_info.raw_events  
 
-    assert Event(
+    event = Event(
         from_address=from_address,
         keys=[get_selector_from_name(name)],
         data=data,
-    ) in raw_events
+    )
+    assert event in raw_events
+
+    return event
 
 contract_classes = {}
 


### PR DESCRIPTION
Following Cairo 0.9 it is now possible to deploy a contract from another contract. This PR adds a method to the account to deploy a smart contract.