### PR TITLE
Fix sessionkey plugin and tests to support v0.9.0

### DIFF
--- a/contracts/ArgentAccount.cairo
+++ b/contracts/ArgentAccount.cairo
@@ -221,6 +221,10 @@ func __execute__{
     if calls[0].selector - USE_PLUGIN_SELECTOR == 0:
         # validate with plugin
         validate_with_plugin(call_array_len, call_array, calldata_len, calldata)
+        tempvar ecdsa_ptr = ecdsa_ptr
+        tempvar syscall_ptr = syscall_ptr
+        tempvar range_check_ptr = range_check_ptr
+        tempvar pedersen_ptr = pedersen_ptr
         jmp do_execute
     else:
         if calls_len == 1:
@@ -230,11 +234,19 @@ func __execute__{
                 if signer_condition == 0:
                     # validate signer signature
                     validate_signer_signature(tx_info.transaction_hash, tx_info.signature, tx_info.signature_len)
+                    tempvar ecdsa_ptr = ecdsa_ptr
+                    tempvar syscall_ptr = syscall_ptr
+                    tempvar range_check_ptr = range_check_ptr
+                    tempvar pedersen_ptr = pedersen_ptr
                     jmp do_execute
                 end
                 if guardian_condition == 0:
                     # validate guardian signature
                     validate_guardian_signature(tx_info.transaction_hash, tx_info.signature, tx_info.signature_len)
+                    tempvar ecdsa_ptr = ecdsa_ptr
+                    tempvar syscall_ptr = syscall_ptr
+                    tempvar range_check_ptr = range_check_ptr
+                    tempvar pedersen_ptr = pedersen_ptr
                     jmp do_execute
                 end
             end
@@ -245,6 +257,10 @@ func __execute__{
         # validate signer and guardian signatures
         validate_signer_signature(tx_info.transaction_hash, tx_info.signature, tx_info.signature_len)
         validate_guardian_signature(tx_info.transaction_hash, tx_info.signature + 2, tx_info.signature_len - 2)
+        tempvar ecdsa_ptr = ecdsa_ptr
+        tempvar syscall_ptr = syscall_ptr
+        tempvar range_check_ptr = range_check_ptr
+        tempvar pedersen_ptr = pedersen_ptr
     end
 
     # execute calls
@@ -316,8 +332,8 @@ func validate_with_plugin{
     let (is_plugin) = _plugins.read(plugin)
     assert_not_zero(is_plugin)
 
-    IPlugin.delegate_validate(
-        contract_address=plugin,
+    IPlugin.library_call_validate(
+        class_hash=plugin,
         plugin_data_len=call_array[0].data_len - 1,
         plugin_data=calldata + call_array[0].data_offset + 1,
         call_array_len=call_array_len - 1,


### PR DESCRIPTION
Please find a fix to the `explore/plugins` branch to make it work with starknet/cairo v0.9.0. This work is based on the `ArgentAccount.cairo` since I do not really understand the goal of the other contracts for now. 

TL;DR:
- it fixes the errors that are showing up at compile time about `revoked` variable
- it changes to `declare` the plugin as a class as, from what I understand, it would not have to be deployed as a contract
- it fixes the `test/plugin_session.py` script

This is the output running the test on `test/plugin_session.py`:

```shell
pytest -v test/plugin_session.py
============================ test session starts ============================
platform darwin -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0 -- plugin/py/bin/python3.9
cachedir: .pytest_cache
rootdir: plugin/argent-contracts-starknet, configfile: pyproject.toml
plugins: asyncio-0.18.3, web3-5.30.0, typeguard-2.13.3
asyncio: mode=legacy
collected 2 items

test/plugin_session.py::test_add_plugin PASSED                        [ 50%]
test/plugin_session.py::test_call_dapp_with_session_key PASSED        [100%]

======================= 2 passed in 102.56s (0:01:42) =======================
```

