### PR TITLE
dev: using pytest.raises instead of assert_revert

### DIFF
--- a/test/utils/utilities.py
+++ b/test/utils/utilities.py
@@ -19,25 +19,11 @@ def str_to_felt(text: str) -> int:
 def uint(a: int) -> Tuple[int, int]:
     return (a, 0)
 
-
-async def assert_revert(expression, expected_message: Optional[str] = None, expected_code: Optional[StarknetErrorCode] = None):
-    if expected_code is None:
-        expected_code = StarknetErrorCode.TRANSACTION_FAILED
-    try:
-        await expression
-        assert False, "Looks like the transaction didn't revert"
-    except StarkException as err:
-        _, error = err.args
-        assert error['code'] == expected_code, f"assert expected: {expected_code}, got error: {error['code']}"
-        if expected_message is not None:
-            errors_found = [s.removeprefix("Error message: ") for s in error['message'].splitlines() if s.startswith("Error message: ")]
-            assert expected_message in errors_found, f"assert expected: {expected_message}, found errors: {errors_found}"
-
 def assert_event_emmited(tx_exec_info: TransactionExecutionInfo, from_address: int, name: str, data: Optional[List[int]] = []):
     if not data:
         raw_events = [Event(from_address=event.from_address, keys=event.keys, data=[]) for event in tx_exec_info.get_sorted_events()]
-    else: 
-        raw_events = [Event(from_address=event.from_address, keys=event.keys, data=event.data) for event in tx_exec_info.get_sorted_events()] 
+    else:
+        raw_events = [Event(from_address=event.from_address, keys=event.keys, data=event.data) for event in tx_exec_info.get_sorted_events()]
 
     assert Event(
         from_address=from_address,
@@ -73,7 +59,6 @@ def cached_contract(state: StarknetState, _class: ContractClass, deployed: Stark
         deploy_call_info=deployed.deploy_call_info
     )
     return contract
-
 
 def get_execute_data(tx_exec_info: TransactionExecutionInfo) -> List[int]:
     raw_data:List[int] = tx_exec_info.call_info.retdata


### PR DESCRIPTION
Hey there,

I started looking into this repo out of interest in the plugin system.

I've noticed the `assert_revert` function you use in your test suite. pytest already ships with a [super cool context manager](https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest-raises) to help with these kind of asserts. This PR then replaces the use of `assert_revert` with `pytest.raises`.

Not sure if you're interested in the PR though. Feel free to close it if you think it's not a good fit, no problem 😎