### PR TITLE
validate_deploy args: decouple account and proxy

### DIFF
--- a/contracts/account/ArgentAccount.cairo
+++ b/contracts/account/ArgentAccount.cairo
@@ -163,8 +163,6 @@ func __validate_deploy__{
     range_check_ptr
 } (
     class_hash: felt,
-    ctr_args_len: felt,
-    ctr_args: felt*,
     salt: felt
 ) {
     alloc_locals;

--- a/contracts/account/ArgentPluginAccount.cairo
+++ b/contracts/account/ArgentPluginAccount.cairo
@@ -180,8 +180,6 @@ func __validate_deploy__{
     range_check_ptr
 } (
     class_hash: felt,
-    ctr_args_len: felt,
-    ctr_args: felt*,
     salt: felt
 ) {
     alloc_locals;

--- a/contracts/upgrade/Proxy.cairo
+++ b/contracts/upgrade/Proxy.cairo
@@ -49,7 +49,7 @@ func __validate_deploy__{
     assert inner_calldata[0] = class_hash;
     assert inner_calldata[1] = salt;
     
-    let (retdata_size: felt, retdata: felt*) = library_call(
+    library_call(
         class_hash=implementation,
         function_selector=VALIDATE_DEPLOY_SELECTOR,
         calldata_size=2,

--- a/contracts/upgrade/Proxy.cairo
+++ b/contracts/upgrade/Proxy.cairo
@@ -1,9 +1,12 @@
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.alloc import alloc
 from starkware.starknet.common.syscalls import library_call, library_call_l1_handler
 
 from contracts.upgrade.Upgradable import _get_implementation, _set_implementation
+
+const VALIDATE_DEPLOY_SELECTOR = 1554466106298962091002569854891683800203193677547440645928814916929210362005;
 
 /////////////////////
 // CONSTRUCTOR
@@ -26,6 +29,34 @@ func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 /////////////////////
 // EXTERNAL FUNCTIONS
 /////////////////////
+
+@external
+func __validate_deploy__{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+} (
+    class_hash: felt,
+    salt: felt,
+    implementation: felt,
+    selector: felt,
+    calldata_len: felt,
+    calldata: felt*
+) {
+    let (implementation) = _get_implementation();
+    
+    let (inner_calldata: felt*) = alloc();
+    assert inner_calldata[0] = class_hash;
+    assert inner_calldata[1] = salt;
+    
+    let (retdata_size: felt, retdata: felt*) = library_call(
+        class_hash=implementation,
+        function_selector=VALIDATE_DEPLOY_SELECTOR,
+        calldata_size=2,
+        calldata=inner_calldata,
+    );
+    return ();
+}
 
 @external
 @raw_input


### PR DESCRIPTION
Alternatively to https://github.com/argentlabs/argent-contracts-starknet/pull/67

This should allow to decouple the account from the proxy. Allows to use any proxy with the account (even if we change the proxy constructor down the road)

**WARNING** i wasn't able to test this yet