### PR TITLE
Fix validate deploy by using raw data

### DIFF
--- a/contracts/account/ArgentAccount.cairo
+++ b/contracts/account/ArgentAccount.cairo
@@ -155,18 +155,15 @@ func __validate_declare__{
     return ();
 }
 
+
+@raw_input
 @external
 func __validate_deploy__{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     ecdsa_ptr: SignatureBuiltin*,
     range_check_ptr
-} (
-    class_hash: felt,
-    ctr_args_len: felt,
-    ctr_args: felt*,
-    salt: felt
-) {
+} (selector: felt, calldata_size: felt, calldata: felt*) {
     alloc_locals;
     // get the tx info
     let (tx_info) = get_tx_info();

--- a/contracts/account/ArgentPluginAccount.cairo
+++ b/contracts/account/ArgentPluginAccount.cairo
@@ -172,18 +172,14 @@ func __validate_declare__{
     return ();
 }
 
+@raw_input
 @external
 func __validate_deploy__{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     ecdsa_ptr: SignatureBuiltin*,
     range_check_ptr
-} (
-    class_hash: felt,
-    ctr_args_len: felt,
-    ctr_args: felt*,
-    salt: felt
-) {
+} (selector: felt, calldata_size: felt, calldata: felt*) {
     alloc_locals;
     // get the tx info
     let (tx_info) = get_tx_info();


### PR DESCRIPTION
An alternative solution to the issue with `__validate_deploy__`
Related to https://github.com/argentlabs/argent-contracts-starknet/pull/68 and https://github.com/argentlabs/argent-contracts-starknet/pull/67

This solution leverages `@raw_input` to accept any input