### PR TITLE
Better typing for calls

### DIFF
--- a/test/argent_account.py
+++ b/test/argent_account.py
@@ -3,7 +3,7 @@ import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
 from utils.Signer import Signer
-from utils.utilities import cached_contract, compile, assert_revert, str_to_felt, assert_event_emmited, update_starknet_block, reset_starknet_block, DEFAULT_TIMESTAMP
+from utils.utilities import cached_contract, compile, assert_revert, str_to_felt, assert_event_emitted, update_starknet_block, reset_starknet_block, DEFAULT_TIMESTAMP
 from utils.TransactionSender import TransactionSender
 
 signer = Signer(1)
@@ -158,7 +158,7 @@ async def test_call_dapp_with_guardian(contract_factory):
     
     tx_exec_info = await sender.send_transaction(calls, [signer, guardian])
 
-    assert_event_emmited(
+    assert_event_emitted(
         tx_exec_info,
         from_address=account.contract_address,
         name='transaction_executed'
@@ -193,7 +193,7 @@ async def test_call_dapp_guardian_backup(contract_factory):
     
     tx_exec_info = await sender.send_transaction(calls, [signer, 0, guardian_backup])
 
-    assert_event_emmited(
+    assert_event_emitted(
         tx_exec_info,
         from_address=account.contract_address,
         name='transaction_executed'
@@ -277,7 +277,7 @@ async def test_change_signer(contract_factory):
     # should work with the correct signers
     tx_exec_info = await sender.send_transaction([(account.contract_address, 'changeSigner', [new_signer.public_key])], [signer, guardian])
     
-    assert_event_emmited(
+    assert_event_emitted(
         tx_exec_info,
         from_address=account.contract_address,
         name='signer_changed',
@@ -308,7 +308,7 @@ async def test_change_guardian(contract_factory):
     # should work with the correct signers
     tx_exec_info = await sender.send_transaction([(account.contract_address, 'changeGuardian', [new_guardian.public_key])], [signer, guardian])
     
-    assert_event_emmited(
+    assert_event_emitted(
         tx_exec_info,
         from_address=account.contract_address,
         name='guardian_changed',
@@ -337,7 +337,7 @@ async def test_change_guardian_backup(contract_factory):
     # should work with the correct signers
     tx_exec_info = await sender.send_transaction([(account.contract_address, 'changeGuardianBackup', [new_guardian_backup.public_key])], [signer, guardian])
     
-    assert_event_emmited(
+    assert_event_emitted(
         tx_exec_info,
         from_address=account.contract_address,
         name='guardian_backup_changed',
@@ -381,7 +381,7 @@ async def test_trigger_escape_guardian_by_signer(contract_factory):
 
     tx_exec_info = await sender.send_transaction([(account.contract_address, 'triggerEscapeGuardian', [])], [signer])
     
-    assert_event_emmited(
+    assert_event_emitted(
         tx_exec_info,
         from_address=account.contract_address,
         name='escape_guardian_triggered',
@@ -404,7 +404,7 @@ async def test_trigger_escape_signer_by_guardian(contract_factory):
 
     tx_exec_info = await sender.send_transaction([(account.contract_address, 'triggerEscapeSigner', [])], [guardian])
 
-    assert_event_emmited(
+    assert_event_emitted(
         tx_exec_info,
         from_address=account.contract_address,
         name='escape_signer_triggered',
@@ -430,7 +430,7 @@ async def test_trigger_escape_signer_by_guardian_backup(contract_factory):
 
     tx_exec_info = await sender.send_transaction([(account.contract_address, 'triggerEscapeSigner', [])], [0, guardian_backup])
 
-    assert_event_emmited(
+    assert_event_emitted(
         tx_exec_info,
         from_address=account.contract_address,
         name='escape_signer_triggered',
@@ -474,7 +474,7 @@ async def test_escape_guardian(contract_factory):
     
     tx_exec_info = await sender.send_transaction([(account.contract_address, 'escapeGuardian', [new_guardian.public_key])], [signer])
 
-    assert_event_emmited(
+    assert_event_emitted(
         tx_exec_info,
         from_address=account.contract_address,
         name='guardian_escaped',
@@ -519,7 +519,7 @@ async def test_escape_signer(contract_factory):
     assert (await account.getSigner().call()).result.signer == (signer.public_key)
     tx_exec_info = await sender.send_transaction([(account.contract_address, 'escapeSigner', [new_signer.public_key])], [guardian])
 
-    assert_event_emmited(
+    assert_event_emitted(
         tx_exec_info,
         from_address=account.contract_address,
         name='signer_escaped',
@@ -598,7 +598,7 @@ async def test_cancel_escape(contract_factory):
     # cancel escape
     tx_exec_info = await sender.send_transaction([(account.contract_address, 'cancelEscape', [])], [signer, guardian])
 
-    assert_event_emmited(
+    assert_event_emitted(
         tx_exec_info,
         from_address=account.contract_address,
         name='escape_canceled',

--- a/test/session_keys.py
+++ b/test/session_keys.py
@@ -3,7 +3,7 @@ import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from starkware.starknet.definitions.general_config import StarknetChainId
 from utils.Signer import Signer
-from utils.utilities import cached_contract, compile, str_to_felt, assert_revert, assert_event_emmited, DEFAULT_TIMESTAMP, update_starknet_block
+from utils.utilities import cached_contract, compile, str_to_felt, assert_revert, assert_event_emitted, DEFAULT_TIMESTAMP, update_starknet_block
 from utils.TransactionSender import TransactionSender
 from starkware.cairo.common.hash_state import compute_hash_on_elements
 from starkware.starknet.compiler.compile import get_selector_from_name
@@ -114,7 +114,7 @@ async def test_call_dapp_with_session_key(contract_factory):
         ], 
         [session_key])
 
-    assert_event_emmited(
+    assert_event_emitted(
         tx_exec_info,
         from_address=account.contract_address,
         name='transaction_executed'
@@ -143,7 +143,7 @@ async def test_call_dapp_with_session_key(contract_factory):
         )],
         [signer]
     )
-    assert_event_emmited(
+    assert_event_emitted(
         tx_exec_info,
         from_address=account.contract_address,
         name='session_key_revoked'

--- a/test/utils/TransactionSender.py
+++ b/test/utils/TransactionSender.py
@@ -12,13 +12,17 @@ from utils.Signer import Signer
 TRANSACTION_VERSION = 1
 
 
+# [target_address, selector, arguments]
+Call = Tuple[str, str, List]
+
+
 class TransactionSender:
     def __init__(self, account: StarknetContract):
         self.account = account
 
     async def send_transaction(
         self,
-        calls: List,
+        calls: List[Call],
         signers: List[Signer],
         nonce: Optional[int] = None,
         max_fee: Optional[int] = 0
@@ -97,7 +101,7 @@ class TransactionSender:
         return execution_info
 
 
-def from_call_to_call_array(calls: List):
+def from_call_to_call_array(calls: List[Call]):
     call_array = []
     calldata = []
     for call in calls:

--- a/test/utils/utilities.py
+++ b/test/utils/utilities.py
@@ -33,17 +33,20 @@ async def assert_revert(expression, expected_message: Optional[str] = None, expe
             errors_found = [s.removeprefix("Error message: ") for s in error['message'].splitlines() if s.startswith("Error message: ")]
             assert expected_message in errors_found, f"assert expected: {expected_message}, found errors: {errors_found}"
 
-def assert_event_emmited(tx_exec_info: TransactionExecutionInfo, from_address: int, name: str, data: Optional[List[int]] = []):
+
+def assert_event_emitted(tx_exec_info: TransactionExecutionInfo, from_address: int, name: str, data: Optional[List[int]] = []):
     if not data:
         raw_events = [Event(from_address=event.from_address, keys=event.keys, data=[]) for event in tx_exec_info.get_sorted_events()]
     else: 
         raw_events = [Event(from_address=event.from_address, keys=event.keys, data=event.data) for event in tx_exec_info.get_sorted_events()] 
 
-    assert Event(
+    event_to_find = Event(
         from_address=from_address,
         keys=[get_selector_from_name(name)],
         data=data,
-    ) in raw_events, f"Event {name} not found"
+    )
+
+    assert event_to_find in raw_events, f"Event {name} not found"
 
 def find_event_emited(tx_exec_info: TransactionExecutionInfo, from_address: int, name: str):
     raw_events = [Event(from_address=event.from_address, keys=event.keys, data=[]) for event in tx_exec_info.get_sorted_events()]
@@ -76,7 +79,7 @@ def cached_contract(state: StarknetState, _class: ContractClass, deployed: Stark
 
 
 def get_execute_data(tx_exec_info: TransactionExecutionInfo) -> List[int]:
-    raw_data:List[int] = tx_exec_info.call_info.retdata
+    raw_data: List[int] = tx_exec_info.call_info.retdata
     ret_execute_size, *ret_execute = raw_data
     assert ret_execute_size == len(ret_execute), "Unexpected return size"
     return ret_execute


### PR DESCRIPTION
- Better typing for calls as suggested by @delaaxe in #64 
- Fix typo in `emitted`