### PR TITLE
New multicall return format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv/
 __pycache__
 artifacts
 node.json
+.idea

--- a/contracts/account/ArgentAccount.cairo
+++ b/contracts/account/ArgentAccount.cairo
@@ -9,12 +9,16 @@ from starkware.starknet.common.syscalls import (
     library_call,
     get_contract_address,
 )
-from contracts.account.library import (
+
+from contracts.utils.calls import (
     Call,
     CallArray,
+    execute_call_array,
+)
+
+from contracts.account.library import (
     Escape,
     ArgentModel,
-    execute_call_array,
     assert_only_self,
     assert_correct_tx_version,
     assert_non_reentrant,

--- a/contracts/account/ArgentAccount.cairo
+++ b/contracts/account/ArgentAccount.cairo
@@ -11,7 +11,6 @@ from starkware.starknet.common.syscalls import (
 )
 
 from contracts.utils.calls import (
-    Call,
     CallArray,
     execute_call_array,
 )

--- a/contracts/account/ArgentPluginAccount.cairo
+++ b/contracts/account/ArgentPluginAccount.cairo
@@ -10,14 +10,16 @@ from starkware.starknet.common.syscalls import (
     get_contract_address,
 )
 from contracts.plugins.IPlugin import IPlugin
-from contracts.account.library import (
+from contracts.utils.calls import (
     Call,
     CallArray,
-    Escape,
-    ArgentModel,
-    from_call_array_to_call,
     execute_call_array,
     execute_calls,
+    from_call_array_to_call
+)
+from contracts.account.library import (
+    Escape,
+    ArgentModel,
     assert_non_reentrant,
     assert_initialized,
     assert_no_self_call,

--- a/contracts/account/library.cairo
+++ b/contracts/account/library.cairo
@@ -17,10 +17,7 @@ from starkware.cairo.common.bool import TRUE, FALSE
 
 from contracts.upgrade.Upgradable import _set_implementation
 
-from contracts.utils.calls import (
-    Call,
-    CallArray,
-)
+from contracts.utils.calls import CallArray
 
 const SUPPORTS_INTERFACE_SELECTOR = 1184015894760294494673613438913361435336722154500302038630992932234692784845;
 const ERC165_ACCOUNT_INTERFACE_ID = 0x3943f10f;

--- a/contracts/account/library.cairo
+++ b/contracts/account/library.cairo
@@ -17,6 +17,11 @@ from starkware.cairo.common.bool import TRUE, FALSE
 
 from contracts.upgrade.Upgradable import _set_implementation
 
+from contracts.utils.calls import (
+    Call,
+    CallArray,
+)
+
 const SUPPORTS_INTERFACE_SELECTOR = 1184015894760294494673613438913361435336722154500302038630992932234692784845;
 const ERC165_ACCOUNT_INTERFACE_ID = 0x3943f10f;
 const ERC165_ACCOUNT_INTERFACE_ID_OLD = 0xf10dbd44; // this is needed to upgrade to this version
@@ -27,22 +32,6 @@ const QUERY_VERSION = 2**128 + TRANSACTION_VERSION;
 /////////////////////
 // STRUCTS
 /////////////////////
-
-struct Call {
-    to: felt,
-    selector: felt,
-    calldata_len: felt,
-    calldata: felt*,
-}
-
-// Tmp struct introduced while we wait for Cairo
-// to support passing `[Call]` to __execute__
-struct CallArray {
-    to: felt,
-    selector: felt,
-    data_offset: felt,
-    data_len: felt,
-}
 
 struct Escape {
     active_at: felt,
@@ -159,77 +148,6 @@ func assert_no_self_call(self: felt, call_array_len: felt, call_array: CallArray
     }
     assert_not_zero(call_array[0].to - self);
     assert_no_self_call(self, call_array_len - 1, call_array + CallArray.SIZE);
-    return ();
-}
-
-// @notice Convenience method to convert an execute a call array
-func execute_call_array{syscall_ptr: felt*}(
-    call_array_len: felt, call_array: CallArray*, calldata_len: felt, calldata: felt*
-) -> (retdata_len: felt, retdata: felt*) {
-    alloc_locals;
-    // convert calls
-    let (calls: Call*) = alloc();
-    from_call_array_to_call(call_array_len, call_array, calldata, calls);
-
-    // execute them
-    let (response: felt*) = alloc();
-    let (response_len) = execute_calls(call_array_len, calls, response, 0);
-    return (retdata_len=response_len, retdata=response);
-}
-
-
-// @notice Executes a list of contract calls recursively.
-// @param calls_len The number of calls to execute
-// @param calls A pointer to the first call to execute
-// @param response The array of felt to populate with the returned data
-// @return response_len The size of the returned data
-func execute_calls{syscall_ptr: felt*}(calls_len: felt, calls: Call*, reponse: felt*, index: felt) -> (
-    response_len: felt
-) {
-    alloc_locals;
-
-    // if no more calls
-    if (calls_len == 0) {
-        return (0,);
-    }
-
-    // do the current call
-    let this_call: Call = [calls];
-    with_attr error_message("argent: multicall {index} failed") {
-        let res = call_contract(
-            contract_address=this_call.to,
-            function_selector=this_call.selector,
-            calldata_size=this_call.calldata_len,
-            calldata=this_call.calldata,
-        );
-    }
-    // copy the result in response
-    memcpy(reponse, res.retdata, res.retdata_size);
-    // do the next calls recursively
-    let (response_len) = execute_calls(calls_len - 1, calls + Call.SIZE, reponse + res.retdata_size, index + 1);
-    return (response_len + res.retdata_size,);
-}
-
-func from_call_array_to_call{syscall_ptr: felt*}(
-    call_array_len: felt, call_array: CallArray*, calldata: felt*, calls: Call*
-) {
-    // if no more calls
-    if (call_array_len == 0) {
-        return ();
-    }
-
-    // parse the current call
-    assert [calls] = Call(
-        to=[call_array].to,
-        selector=[call_array].selector,
-        calldata_len=[call_array].data_len,
-        calldata=calldata + [call_array].data_offset
-    );
-
-    // parse the remaining calls recursively
-    from_call_array_to_call(
-        call_array_len - 1, call_array + CallArray.SIZE, calldata, calls + Call.SIZE
-    );
     return ();
 }
 

--- a/contracts/lib/Multicall.cairo
+++ b/contracts/lib/Multicall.cairo
@@ -3,49 +3,94 @@
 from starkware.starknet.common.syscalls import call_contract, get_block_number
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.memcpy import memcpy
+from contracts.utils.calls import (
+    Call,
+    CallArray,
+    from_call_array_to_call,
+)
+
 
 // ////////////////////////////////////////////////////////////////////////
 // The Multicall contract can call an array of view methods on different
 // contracts and return the aggregate response as an array.
-// E.g.
-// Input: [to_1, selector_1, data_1_len, data_1, ..., to_N, selector_N, data_N_len, data_N]
-// Output: [result_1 + .... + result_N]
-// ////////////////////////////////////////////////////////////////////////
-
+// Input: same as the IAccount.__execute__ 
+// @return (block_number, retdata_size, retdata)
+//   Where retdata is [len(call_1_data), *call_1_data, len(call_1_data), *call_2_data, ..., len(call_N_data), *call_N_data]
+// ///////////////////////////////////////////////////////////////////////
 @view
-func aggregate{syscall_ptr: felt*, range_check_ptr}(calls_len: felt, calls: felt*) -> (
-    block_number: felt, result_len: felt, result: felt*
+func aggregate{syscall_ptr: felt*, range_check_ptr}(
+    call_array_len: felt,
+    call_array: CallArray*,
+    calldata_len: felt,
+    calldata: felt*
+) -> (
+    block_number: felt, retdata_len: felt, retdata: felt*
+) {
+    alloc_locals;
+    let (retdata_len, retdata) = execute_call_array_detailed(call_array_len, call_array, calldata_len, calldata);
+    let (block_number) = get_block_number();
+    return (block_number=block_number, retdata_len=retdata_len, retdata=retdata);
+}
+
+
+// @notice Convenience method to convert an execute a call array
+// @return response_len: The size of the returned data
+// @return response: Data return 
+//   in the form [len(call_1_data), *call_1_data, len(call_1_data), *call_2_data, ..., len(call_N_data), *call_N_data]
+func execute_call_array_detailed{syscall_ptr: felt*}(
+    call_array_len: felt, call_array: CallArray*, calldata_len: felt, calldata: felt*
+) -> (retdata_len: felt, retdata: felt*) {
+    alloc_locals;
+    // convert calls
+    let (calls: Call*) = alloc();
+    from_call_array_to_call(call_array_len, call_array, calldata, calls);
+
+    // execute them
+    let (response: felt*) = alloc();
+    let (response_len) = execute_calls_detailed(call_array_len, calls, response, 0);
+    return (retdata_len=response_len, retdata=response);
+}
+
+
+// @notice Executes a list of contract calls recursively.
+// @param calls_len The number of calls to execute
+// @param calls A pointer to the first call to execute
+// @param response The array of felt to populate with the returned data
+//   in the form [len(call_1_data), *call_1_data, len(call_1_data), *call_2_data, ..., len(call_N_data), *call_N_data]
+// @return response_len The size of the returned data
+func execute_calls_detailed{syscall_ptr: felt*}(calls_len: felt, calls: Call*, response: felt*, index: felt) -> (
+    response_len: felt
 ) {
     alloc_locals;
 
-    let (result: felt*) = alloc();
-    let (result_len) = call_loop(calls_len=calls_len, calls=calls, result=result);
-    let (block_number) = get_block_number();
-
-    return (block_number=block_number, result_len=result_len, result=result);
-}
-
-func call_loop{syscall_ptr: felt*, range_check_ptr}(
-    calls_len: felt, calls: felt*, result: felt*
-) -> (result_len: felt) {
+    // if no more calls
     if (calls_len == 0) {
         return (0,);
     }
-    alloc_locals;
 
-    let response = call_contract(
-        contract_address=[calls],
-        function_selector=[calls + 1],
-        calldata_size=[calls + 2],
-        calldata=&[calls + 3],
+    // do the current call
+    let this_call: Call = [calls];
+    with_attr error_message("multicall {index} failed") {
+        let res = call_contract(
+            contract_address=this_call.to,
+            function_selector=this_call.selector,
+            calldata_size=this_call.calldata_len,
+            calldata=this_call.calldata,
+        );
+    }
+    // copy the result in response
+    assert [response] = res.retdata_size;
+    memcpy(
+        dst=response + 1,
+        src=res.retdata,
+        len=res.retdata_size
     );
-
-    memcpy(result, response.retdata, response.retdata_size);
-
-    let (len) = call_loop(
-        calls_len=calls_len - (3 + [calls + 2]),
-        calls=calls + (3 + [calls + 2]),
-        result=result + response.retdata_size,
+    // do the next calls recursively
+    let (response_len) = execute_calls_detailed(
+        calls_len=calls_len - 1,
+        calls=calls + Call.SIZE,
+        response=response + res.retdata_size + 1,
+        index=index + 1
     );
-    return (len + response.retdata_size,);
+    return (response_len + res.retdata_size + 1,);
 }

--- a/contracts/lib/Multicall.cairo
+++ b/contracts/lib/Multicall.cairo
@@ -27,7 +27,7 @@ func aggregate{syscall_ptr: felt*, range_check_ptr}(
     block_number: felt, retdata_len: felt, retdata: felt*
 ) {
     alloc_locals;
-    let (retdata_len, retdata) = execute_call_array_detailed(call_array_len, call_array, calldata_len, calldata);
+    let (retdata_len, retdata) = do_call_array(call_array_len, call_array, calldata_len, calldata);
     let (block_number) = get_block_number();
     return (block_number=block_number, retdata_len=retdata_len, retdata=retdata);
 }
@@ -37,7 +37,7 @@ func aggregate{syscall_ptr: felt*, range_check_ptr}(
 // @return response_len: The size of the returned data
 // @return response: Data return 
 //   in the form [len(call_1_data), *call_1_data, len(call_1_data), *call_2_data, ..., len(call_N_data), *call_N_data]
-func execute_call_array_detailed{syscall_ptr: felt*}(
+func do_call_array{syscall_ptr: felt*}(
     call_array_len: felt, call_array: CallArray*, calldata_len: felt, calldata: felt*
 ) -> (retdata_len: felt, retdata: felt*) {
     alloc_locals;
@@ -47,7 +47,7 @@ func execute_call_array_detailed{syscall_ptr: felt*}(
 
     // execute them
     let (response: felt*) = alloc();
-    let (response_len) = execute_calls_detailed(call_array_len, calls, response, 0);
+    let (response_len) = do_calls(call_array_len, calls, response, 0);
     return (retdata_len=response_len, retdata=response);
 }
 
@@ -58,7 +58,7 @@ func execute_call_array_detailed{syscall_ptr: felt*}(
 // @param response The array of felt to populate with the returned data
 //   in the form [len(call_1_data), *call_1_data, len(call_1_data), *call_2_data, ..., len(call_N_data), *call_N_data]
 // @return response_len The size of the returned data
-func execute_calls_detailed{syscall_ptr: felt*}(calls_len: felt, calls: Call*, response: felt*, index: felt) -> (
+func do_calls{syscall_ptr: felt*}(calls_len: felt, calls: Call*, response: felt*, index: felt) -> (
     response_len: felt
 ) {
     alloc_locals;
@@ -86,7 +86,7 @@ func execute_calls_detailed{syscall_ptr: felt*}(calls_len: felt, calls: Call*, r
         len=res.retdata_size
     );
     // do the next calls recursively
-    let (response_len) = execute_calls_detailed(
+    let (response_len) = do_calls(
         calls_len=calls_len - 1,
         calls=calls + Call.SIZE,
         response=response + res.retdata_size + 1,

--- a/contracts/utils/calls.cairo
+++ b/contracts/utils/calls.cairo
@@ -1,0 +1,110 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.memcpy import memcpy
+from starkware.cairo.common.math import assert_not_zero, assert_le, assert_nn
+from starkware.starknet.common.syscalls import call_contract
+from starkware.cairo.common.bool import TRUE, FALSE
+
+struct Call {
+    to: felt,
+    selector: felt,
+    calldata_len: felt,
+    calldata: felt*,
+}
+
+// Tmp struct introduced while we wait for Cairo
+// to support passing `[Call]` to __execute__
+struct CallArray {
+    to: felt,
+    selector: felt,
+    data_offset: felt,
+    data_len: felt,
+}
+
+func from_call_array_to_call{syscall_ptr: felt*}(
+    call_array_len: felt, call_array: CallArray*, calldata: felt*, calls: Call*
+) {
+    // if no more calls
+    if (call_array_len == 0) {
+        return ();
+    }
+
+    // parse the current call
+    assert [calls] = Call(
+        to=[call_array].to,
+        selector=[call_array].selector,
+        calldata_len=[call_array].data_len,
+        calldata=calldata + [call_array].data_offset
+    );
+
+    // parse the remaining calls recursively
+    from_call_array_to_call(
+        call_array_len - 1, call_array + CallArray.SIZE, calldata, calls + Call.SIZE
+    );
+    return ();
+}
+
+
+// @notice Convenience method to convert an execute a call array
+// @return response_len: The size of the returned data
+// @return response: Data return 
+//   in the form [*call_1_data, *call_2_data, ..., *call_N_data]
+func execute_call_array{syscall_ptr: felt*}(
+    call_array_len: felt, call_array: CallArray*, calldata_len: felt, calldata: felt*
+) -> (retdata_len: felt, retdata: felt*) {
+    alloc_locals;
+    // convert calls
+    let (calls: Call*) = alloc();
+    from_call_array_to_call(call_array_len, call_array, calldata, calls);
+
+    // execute them
+    let (response: felt*) = alloc();
+    let (response_len) = execute_calls(call_array_len, calls, response, 0);
+    return (retdata_len=response_len, retdata=response);
+}
+
+
+// @notice Executes a list of contract calls recursively.
+// @param calls_len The number of calls to execute
+// @param calls A pointer to the first call to execute
+// @param response The array of felt to populate with the returned data
+//   in the form [*call_1_data, *call_2_data, ..., *call_N_data]
+// @return response_len The size of the returned data
+func execute_calls{syscall_ptr: felt*}(calls_len: felt, calls: Call*, response: felt*, index: felt) -> (
+    response_len: felt
+) {
+    alloc_locals;
+
+    // if no more calls
+    if (calls_len == 0) {
+        return (0,);
+    }
+
+    // do the current call
+    let this_call: Call = [calls];
+    with_attr error_message("multicall {index} failed") {
+        let res = call_contract(
+            contract_address=this_call.to,
+            function_selector=this_call.selector,
+            calldata_size=this_call.calldata_len,
+            calldata=this_call.calldata,
+        );
+    }
+    // copy the result in response
+    memcpy(
+        dst=response,
+        src=res.retdata,
+        len=res.retdata_size
+    );
+    // do the next calls recursively
+    let (response_len) = execute_calls(
+        calls_len=calls_len - 1,
+        calls=calls + Call.SIZE,
+        response=response + res.retdata_size,
+        index=index + 1
+    );
+    return (response_len + res.retdata_size,);
+}
+

--- a/test/test_argent_account.py
+++ b/test/test_argent_account.py
@@ -232,7 +232,7 @@ async def test_multicall(contract_factory):
     account, _, dapp = contract_factory
     sender = TransactionSender(account)
 
-    # should reverts when one of the call is to the account
+    # should revert when one of the call is to the account
     await assert_revert(
         sender.send_transaction([(dapp.contract_address, 'set_number', [47]), (account.contract_address, 'triggerEscapeGuardian', [])], [signer, guardian])
     )
@@ -243,11 +243,11 @@ async def test_multicall(contract_factory):
     # should indicate which called failed
     await assert_revert(
         sender.send_transaction([(dapp.contract_address, 'set_number', [47]), (dapp.contract_address, 'throw_error', [1])], [signer, guardian]),
-        "argent: multicall 1 failed"
+        "multicall 1 failed"
     )
     await assert_revert(
         sender.send_transaction([(dapp.contract_address, 'throw_error', [1]), (dapp.contract_address, 'set_number', [47])], [signer, guardian]),
-        "argent: multicall 0 failed"
+        "multicall 0 failed"
     )
 
     # should call the dapp

--- a/test/test_multicall.py
+++ b/test/test_multicall.py
@@ -44,7 +44,7 @@ async def test_multicall():
     response = await multicall.aggregate(call_array, calldata).call()
 
     assert response.result.retdata == [
-            1, 18,
-            2, 1000, 0,
-            2, 1000, 0
+            1, 18,       # 1st call result
+            2, 1000, 0,  # 2nd call result
+            2, 1000, 0   # 3rd call result
     ]

--- a/test/test_multicall.py
+++ b/test/test_multicall.py
@@ -3,13 +3,16 @@ import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from starkware.starknet.public.abi import get_selector_from_name
 from utils.utilities import compile, str_to_felt
+from utils.TransactionSender import from_call_to_call_array
 
 user1 = 0x69221ff9023c4d7ba9123f0f9c32634c23fc5776d86657f464ecb51fd811445
 user2 = 0x72648c3b1953572d2c4395a610f18b83cca14fa4d1ba10fc4484431fd463e5c
 
+
 @pytest.fixture(scope='module')
 def event_loop():
     return asyncio.new_event_loop()
+
 
 @pytest.mark.asyncio
 async def test_multicall():
@@ -33,12 +36,15 @@ async def test_multicall():
         constructor_calldata=[str_to_felt('token2'), str_to_felt('T2'), user2]
     )
 
-    response = await multicall.aggregate([
-        erc20_1.contract_address, get_selector_from_name('decimals'), 0,
-        erc20_1.contract_address, get_selector_from_name('balanceOf'), 1, user1,
-        erc20_2.contract_address, get_selector_from_name('balanceOf'), 1, user2
-    ]).call()
+    call_array, calldata = from_call_to_call_array([
+        (erc20_1.contract_address, 'decimals', []),
+        (erc20_1.contract_address, 'balanceOf', [user1]),
+        (erc20_2.contract_address, 'balanceOf', [user2])
+    ])
+    response = await multicall.aggregate(call_array, calldata).call()
 
-    assert response.result.result[0] == 18
-    assert response.result.result[1] == 1000
-    assert response.result.result[3] == 1000
+    assert response.result.retdata == [
+            1, 18,
+            2, 1000, 0,
+            2, 1000, 0
+    ]

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -289,5 +289,5 @@ async def test_execute_after_upgrade_safety(contract_factory):
             [build_upgrade_call(account, account_2_class, [change_signer_call])],
             [signer, guardian]
         ),
-        "argent: multicall 0 failed"
+        "multicall 0 failed"
     )


### PR DESCRIPTION
https://argent.atlassian.net/browse/BLKC-30

The new data return type is goes like this:
```
[
  3, (1, 2, 3),
  1, (9)
]
```
In the ticket it was suggested to add another felt in the first position with the number of calls, but the client already knows the number of calls it made, so i dropped it.

