### PR TITLE
use `check_ecdsa_signature`

### DIFF
--- a/contracts/account/ArgentAccount.cairo
+++ b/contracts/account/ArgentAccount.cairo
@@ -1,6 +1,6 @@
 %lang starknet
 
-from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin, EcOpBuiltin
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math import assert_not_zero
 from starkware.starknet.common.syscalls import (
@@ -57,6 +57,7 @@ func __validate__{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     ecdsa_ptr: SignatureBuiltin*,
+    ec_op_ptr: EcOpBuiltin*,
     range_check_ptr
 } (
     call_array_len: felt,
@@ -113,7 +114,6 @@ func __validate__{
 func __execute__{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
-    ecdsa_ptr: SignatureBuiltin*,
     range_check_ptr
 } (
     call_array_len: felt,
@@ -148,6 +148,7 @@ func __validate_declare__{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     ecdsa_ptr: SignatureBuiltin*,
+    ec_op_ptr: EcOpBuiltin*,
     range_check_ptr
 } (
     class_hash: felt
@@ -170,6 +171,7 @@ func __validate_deploy__{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     ecdsa_ptr: SignatureBuiltin*,
+    ec_op_ptr: EcOpBuiltin*,
     range_check_ptr
 } (selector: felt, calldata_size: felt, calldata: felt*) {
     alloc_locals;
@@ -185,7 +187,7 @@ func __validate_deploy__{
 
 @view
 func isValidSignature{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ecdsa_ptr: SignatureBuiltin*, range_check_ptr
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ec_op_ptr: EcOpBuiltin*, range_check_ptr
 }(hash: felt, sig_len: felt, sig: felt*) -> (isValid: felt) {
     let (isValid) = ArgentModel.is_valid_signature(hash, sig_len, sig);
     return (isValid=isValid);
@@ -406,7 +408,7 @@ func getName() -> (name: felt) {
 // @dev DEPRECATED: Remove when isValidSignature() is widely used
 @view
 func is_valid_signature{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ecdsa_ptr: SignatureBuiltin*, range_check_ptr
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ec_op_ptr: EcOpBuiltin*, range_check_ptr
 }(hash: felt, sig_len: felt, sig: felt*) -> (is_valid: felt) {
     let (is_valid) = ArgentModel.is_valid_signature(hash, sig_len, sig);
     return (is_valid=is_valid);

--- a/contracts/account/ArgentPluginAccount.cairo
+++ b/contracts/account/ArgentPluginAccount.cairo
@@ -1,6 +1,6 @@
 %lang starknet
 
-from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin, EcOpBuiltin
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math import assert_not_zero
 from starkware.starknet.common.syscalls import (
@@ -70,6 +70,7 @@ func __validate__{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     ecdsa_ptr: SignatureBuiltin*,
+    ec_op_ptr: EcOpBuiltin*,
     range_check_ptr
 } (
     call_array_len: felt,
@@ -133,7 +134,6 @@ func __validate__{
 func __execute__{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
-    ecdsa_ptr: SignatureBuiltin*,
     range_check_ptr
 } (
     call_array_len: felt,
@@ -167,6 +167,7 @@ func __validate_declare__{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     ecdsa_ptr: SignatureBuiltin*,
+    ec_op_ptr: EcOpBuiltin*,
     range_check_ptr
 } (
     class_hash: felt
@@ -188,6 +189,7 @@ func __validate_deploy__{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
     ecdsa_ptr: SignatureBuiltin*,
+    ec_op_ptr: EcOpBuiltin*,
     range_check_ptr
 } (selector: felt, calldata_size: felt, calldata: felt*) {
     alloc_locals;
@@ -203,7 +205,7 @@ func __validate_deploy__{
 
 @view
 func isValidSignature{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ecdsa_ptr: SignatureBuiltin*, range_check_ptr
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ec_op_ptr: EcOpBuiltin*, range_check_ptr
 }(hash: felt, sig_len: felt, sig: felt*) -> (is_valid: felt) {
     let (is_valid) = ArgentModel.is_valid_signature(hash, sig_len, sig);
     return (is_valid=is_valid);
@@ -518,7 +520,7 @@ func getName() -> (name: felt) {
 // @dev DEPRECATED: Remove when isValidSignature() is widely used
 @view
 func is_valid_signature{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ecdsa_ptr: SignatureBuiltin*, range_check_ptr
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ec_op_ptr: EcOpBuiltin*, range_check_ptr
 }(hash: felt, sig_len: felt, sig: felt*) -> (is_valid: felt) {
     let (is_valid) = ArgentModel.is_valid_signature(hash, sig_len, sig);
     return (is_valid=is_valid);

--- a/test/test_argent_deploy.py
+++ b/test/test_argent_deploy.py
@@ -78,7 +78,7 @@ async def test_validate_deploy_errors(deploy_env_copy: Tuple[Starknet, DeclaredC
             contract_cls=proxy_cls,
             signature=[]
         ),
-        expected_message="argent: signer signature invalid"
+        expected_message="argent: signature format invalid"
     )
 
     # Test with signer only


### PR DESCRIPTION
This PR introduces the newly available `check_ecdsa_signature` which allows to verify an ecdsa signature without reverting.  This enables to simplify the logic of the guardian backup: the signature of the guardian backup can now be placed after the signer's signature (no need to put an empty signature first). 

Closes #82 .