### PR TITLE
Update dummy syscalls return types

### DIFF
--- a/contracts/asserts.cairo
+++ b/contracts/asserts.cairo
@@ -1,17 +1,19 @@
-use contracts::dummy_syscalls;
+use contracts::dummy_syscalls::get_contract_address;
+use contracts::dummy_syscalls::get_caller_address;
+use zeroable::Zeroable;
+use starknet::ContractAddressZeroable;
+use traits::Into;
+use starknet::ContractAddressIntoFelt;
 
 const TRANSACTION_VERSION: felt = 1;
 const QUERY_VERSION: felt = 340282366920938463463374607431768211457; // 2**128 + TRANSACTION_VERSION
 
 fn assert_only_self() {
-    let self = dummy_syscalls::get_contract_address();
-    let caller_address = dummy_syscalls::get_caller_address();
-    assert(self == caller_address, 'argent/only-self');
+    assert(get_contract_address().into() == get_caller_address().into(), 'argent/only-self');
 }
 
 fn assert_non_reentrant(signer: felt) {
-    let caller_address = dummy_syscalls::get_caller_address();
-    assert(caller_address == 0, 'argent/no-reentrant-call');
+    assert(get_caller_address().is_zero(), 'argent/no-reentrant-call');
 }
 
 fn assert_correct_tx_version(tx_version: felt) {

--- a/contracts/dummy_syscalls.cairo
+++ b/contracts/dummy_syscalls.cairo
@@ -1,17 +1,20 @@
-fn get_contract_address() -> felt {
-    69
+use starknet::ContractAddress;
+use starknet::contract_address_const;
+
+fn get_contract_address() -> ContractAddress {
+    contract_address_const::<69>()
 }
 
-fn get_caller_address() -> felt {
-    69
+fn get_caller_address() -> ContractAddress {
+    contract_address_const::<69>()
 }
 
-fn get_block_number() -> felt {
-    1
+fn get_block_number() -> u64 {
+    1_u64
 }
 
 fn get_tx_info() {}
 
-fn call_contract(to: felt, selector: felt, calldata: Array::<felt>) -> Array::<felt> {
+fn call_contract(to: felt, selector: felt, calldata: @Array::<felt>) -> Array::<felt> {
     array_new()
 }

--- a/contracts/test_dapp.cairo
+++ b/contracts/test_dapp.cairo
@@ -1,13 +1,14 @@
 #[contract]
 mod TestDapp {
     use contracts::dummy_syscalls;
+    use starknet::ContractAddress;
 
     /////////////////////
     // STORAGE VARIABLES
     ////////////////////
 
     struct Storage {
-        stored_number: LegacyMap::<felt, felt>, 
+        stored_number: LegacyMap::<ContractAddress, felt>, 
     }
 
     /////////////////////
@@ -51,7 +52,7 @@ mod TestDapp {
     /////////////////////
 
     #[view]
-    fn get_number(user: felt) -> (felt) {
+    fn get_number(user: ContractAddress) -> (felt) {
         stored_number::read(user)
     }
 }


### PR DESCRIPTION
Updating our dummy syscalls to use the corrects types, so the rest of the code we build afterwards is already correct